### PR TITLE
[P0] 增加 GitHub Actions 质量门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: P0 quality gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: p0-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Typecheck, test, build and audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: sampleflow
+          POSTGRES_USER: sampleflow
+          POSTGRES_PASSWORD: sampleflow_dev
+        ports:
+          - 55432:5432
+        options: >-
+          --health-cmd "pg_isready -U sampleflow -d sampleflow"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+
+      - name: 安装 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: 安装依赖
+        run: npm ci
+
+      - name: 安装 Chromium 及系统依赖
+        run: npx playwright install --with-deps chromium
+
+      - name: 执行完整质量门禁
+        run: npm run verify
+        env:
+          TEST_DATABASE_ADMIN_URL: postgresql://sampleflow:sampleflow_dev@127.0.0.1:55432/postgres
+
+      - name: 保存 Playwright 失败报告
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## 范围

- 新增 GitHub Actions P0 质量门禁。
- 在独立 PostgreSQL 16 服务上执行现有 `npm run verify`：typecheck、unit/integration、Web E2E、build、生产依赖审计和 Compose 配置检查。
- 安装真实 Chromium；失败时保留 Playwright 报告 7 天。
- 使用只读仓库权限，并取消同一分支的过时运行。

## 本地验证

- UTF-8 YAML 解析通过。
- `git diff --check` 通过。
- 同一 `npm run verify` 已在前一合并切片通过：25 项 API、2 项 Playwright E2E、构建与审计均为绿色。

## 边界

- 这是 Issue #1 的 CI 子任务，不会提前关闭 #1；#2—#7/#9 的场景仍需逐项进入回归矩阵。
- 未启用分支保护；该权限变更保留给仓库所有者确认。

Part of #1
