### PR TITLE
ci: 升级官方 Actions 运行时

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: 检出代码
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 安装 Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -55,7 +55,7 @@ jobs:
 
       - name: 保存 Playwright 失败报告
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: apps/web/playwright-report/


### PR DESCRIPTION
## 范围

- 将 checkout、setup-node、upload-artifact 从 v4 升级到官方当前主版本 v7。
- 不改变质量门禁步骤、权限或触发条件。

## 依据

- main 首次门禁已通过，但 GitHub 标注 checkout/setup-node 的 Node 20 运行时已弃用。
- 2026-08-27 通过 GitHub API 核对，三个官方 Action 的最新发布均为 v7。

Part of #1
