### PR TITLE
feat: add stable order pagination

### DIFF
--- a/apps/api/migrations/019_performance_order_cursor.sql
+++ b/apps/api/migrations/019_performance_order_cursor.sql
@@ -1,0 +1,1 @@
+create index performance_orders_created_cursor_idx on performance_orders(created_at desc,id desc);

--- a/apps/api/src/authorization.integration.test.ts
+++ b/apps/api/src/authorization.integration.test.ts
@@ -2,13 +2,14 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
 import pg from "pg";
+import { buildApp } from "./app.js";
 import { seedTestUser } from "./test-support/fixtures.js";
 import { withTestApi } from "./test-support/test-api.js";
 import { withMigratedTestDatabase } from "./test-support/test-database.js";
 import { resolvePerformanceAccess } from "./modules/authorization.js";
 import { ORGANIZATION_ACHIEVEMENT_SQL } from "./modules/performance.js";
 
-const { Client } = pg;
+const { Client, Pool } = pg;
 const TEST_ORIGIN = "http://127.0.0.1:4174";
 
 function moneyCents(value: string): bigint {
@@ -1183,6 +1184,180 @@ test("账号管理接口返回与服务端授权同源的只读角色权限矩�
       assert.ok(matrix.find((role) => role.code === "sales_assistant_leader")?.businessOperations.includes("月度核对与关闭月更正"));
       assert.ok(matrix.find((role) => role.code === "hr")?.businessOperations.includes("记账期间关闭与更正审批"));
     });
+  });
+});
+
+test("订单台账用固定快照稳定遍历并保持有界查询次数", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    const scenario = await seedAuthorizationScenario(database.url);
+    const setup = new Client({ connectionString: database.url });
+    await setup.connect();
+    const organization = await setup.query<{ department_id: string; group_id: string }>(
+      `select (select id::text from org_units where unit_type='department' and name='甲部') as department_id,
+              (select id::text from org_units where unit_type='group' and name='甲组') as group_id`,
+    );
+    const { department_id: departmentId, group_id: groupId } = organization.rows[0]!;
+    const fixedCreatedAt = "2026-08-31T12:00:00.000Z";
+    async function insertRows(prefix: string, count: number): Promise<string[]> {
+      const inserted = await setup.query<{ id: string }>(
+        `with orders as (
+           insert into performance_orders
+             (qingflow_order_no,customer_name,customer_unit,salesperson_person_id,salesperson_name,
+              source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,created_at,posted_at)
+           select $1||lpad(series::text,4,'0'),'游标客户'||lpad(series::text,4,'0'),
+                  '游标单位'||lpad(series::text,4,'0'),$3,'游标业务员','2026-08-31',1,1,1,'active',$4,$4
+           from generate_series(1,$2::integer) series
+           returning id
+         )
+         insert into performance_events
+           (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,
+            accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,
+            department_unit_id,department_name,group_unit_id,group_name,leader_person_id,leader_name,
+            supervisor_person_id,supervisor_name)
+         select id,'initial',1,1,1,'2026-08-01','2026-08-31','稳定游标回归',$3,'游标业务员',
+                $5,'甲部',$6,'甲组',$7,'甲组组长',$8,'甲部主管'
+         from orders returning order_id::text as id`,
+        [
+          prefix,
+          count,
+          scenario.people[scenario.users.alice],
+          fixedCreatedAt,
+          departmentId,
+          groupId,
+          scenario.people[scenario.users.leader],
+          scenario.people[scenario.users.supervisor],
+        ],
+      );
+      return inserted.rows.map((row) => row.id);
+    }
+
+    const expectedIds = await insertRows("CURSOR-FIX-", 101);
+    const pool = new Pool({ connectionString: database.url });
+    let listReadCount = 0;
+    let orderListQuery: { statement: string; values: unknown[] } | null = null;
+    const patched = new WeakSet<pg.PoolClient>();
+    pool.on("acquire", (client) => {
+      if (patched.has(client)) return;
+      patched.add(client);
+      const originalQuery = client.query.bind(client);
+      client.query = ((...args: unknown[]) => {
+        const statement = typeof args[0] === "string" ? args[0] : String((args[0] as { text?: string })?.text ?? "");
+        if (/^\s*(select|with)\b/i.test(statement) && !/\bfrom sessions\b/i.test(statement)) listReadCount += 1;
+        if (/select id::text, created_at as "__cursorCreatedAt"/i.test(statement)) {
+          const values = typeof args[0] === "string" ? args[1] : (args[0] as { values?: unknown[] }).values;
+          orderListQuery = { statement, values: Array.isArray(values) ? [...values] : [] };
+        }
+        return originalQuery(...args as [string, unknown[]]);
+      }) as typeof client.query;
+    });
+    const app = await buildApp({ database: pool, logger: false });
+    try {
+      const leaderCookie = await loginCookie(app, "scope_leader");
+      type OrderPage = {
+        orders: Array<{ id: string; orderNo: string; customerName: string; customerUnit: string; salespersonName: string }>;
+        previousCursor: string | null;
+        nextCursor: string | null;
+        pageSize: number;
+      };
+      async function readPage(search: string, cursor?: string, cookie = leaderCookie): Promise<{ body: OrderPage; reads: number }> {
+        const query = new URLSearchParams({ search });
+        if (cursor) query.set("cursor", cursor);
+        listReadCount = 0;
+        const response = await app.inject({ method: "GET", url: `/api/performance/orders?${query}`, headers: { cookie } });
+        assert.equal(response.statusCode, 200, response.body);
+        assert.ok(listReadCount <= 2, `排除会话认证后，订单列表权限与数据读取应不超过 2 次，实际 ${listReadCount} 次`);
+        return { body: response.json() as OrderPage, reads: listReadCount };
+      }
+      async function assertListPlanHasNoPerRowEventScan() {
+        assert.ok(orderListQuery);
+        type PlanNode = { "Parent Relationship"?: string; "Relation Name"?: string; "Actual Loops"?: number; Plans?: PlanNode[] };
+        const explained = await setup.query<{ "QUERY PLAN": Array<{ Plan: PlanNode }> }>(
+          `explain (analyze,format json) ${orderListQuery.statement}`,
+          orderListQuery.values,
+        );
+        const repeatedNodes: PlanNode[] = [];
+        const visit = (node: PlanNode) => {
+          if ((node["Actual Loops"] ?? 0) > 1
+            && (node["Parent Relationship"] === "SubPlan" || node["Relation Name"] === "performance_events")) repeatedNodes.push(node);
+          node.Plans?.forEach(visit);
+        };
+        const plan = explained.rows[0]!["QUERY PLAN"][0]!.Plan;
+        visit(plan);
+        assert.deepEqual(repeatedNodes, [], JSON.stringify(plan));
+      }
+
+      const first = await readPage("CURSOR-FIX-");
+      await assertListPlanHasNoPerRowEventScan();
+      assert.equal(first.body.pageSize, 50);
+      assert.equal(first.body.orders.length, 50);
+      assert.equal(first.body.previousCursor, null);
+      assert.ok(first.body.nextCursor);
+
+      const [newOrderId] = await insertRows("CURSOR-FIX-NEW-", 1);
+      const pages = [first.body];
+      let nextCursor: string | null = first.body.nextCursor;
+      while (nextCursor) {
+        const currentPage: OrderPage = (await readPage("CURSOR-FIX-", nextCursor)).body;
+        pages.push(currentPage);
+        nextCursor = currentPage.nextCursor;
+      }
+      assert.deepEqual(pages.map((page) => page.orders.length), [50, 50, 1]);
+      const traversedIds = pages.flatMap((page) => page.orders.map((order) => order.id));
+      assert.equal(new Set(traversedIds).size, 101);
+      assert.deepEqual(new Set(traversedIds), new Set(expectedIds));
+      assert.ok(!traversedIds.includes(newOrderId!));
+
+      const previous = await readPage("CURSOR-FIX-", pages[1]!.previousCursor!);
+      assert.deepEqual(previous.body.orders.map((order) => order.id), pages[0]!.orders.map((order) => order.id));
+      assert.equal(previous.body.previousCursor, null);
+      assert.ok(previous.body.nextCursor);
+      const refreshed = await readPage("CURSOR-FIX-");
+      assert.equal(refreshed.body.orders[0]!.id, newOrderId);
+
+      for (const [search, field, expected] of [
+        ["CURSOR-FIX-0001", "orderNo", "CURSOR-FIX-0001"],
+        ["游标客户0002", "customerName", "游标客户0002"],
+        ["游标单位0003", "customerUnit", "游标单位0003"],
+        ["游标业务员", "salespersonName", "游标业务员"],
+      ] as const) {
+        const page = await readPage(search);
+        assert.ok(page.body.orders.length > 0, search);
+        assert.ok(page.body.orders.every((order) => order[field].includes(expected)), search);
+      }
+
+      const mismatch = await app.inject({
+        method: "GET",
+        url: `/api/performance/orders?search=OTHER&cursor=${encodeURIComponent(first.body.nextCursor!)}`,
+        headers: { cookie: leaderCookie },
+      });
+      assert.equal(mismatch.statusCode, 400, mismatch.body);
+      const bobCookie = await loginCookie(app, "scope_bob");
+      const otherUser = await app.inject({
+        method: "GET",
+        url: `/api/performance/orders?search=CURSOR-FIX-&cursor=${encodeURIComponent(first.body.nextCursor!)}`,
+        headers: { cookie: bobCookie },
+      });
+      assert.equal(otherUser.statusCode, 400, otherUser.body);
+      const oversizedPayload = JSON.parse(Buffer.from(first.body.nextCursor!, "base64url").toString("utf8")) as Record<string, unknown>;
+      oversizedPayload.anchorId = "9223372036854775808";
+      const oversizedCursor = Buffer.from(JSON.stringify(oversizedPayload), "utf8").toString("base64url");
+      const oversized = await app.inject({
+        method: "GET",
+        url: `/api/performance/orders?search=CURSOR-FIX-&cursor=${encodeURIComponent(oversizedCursor)}`,
+        headers: { cookie: leaderCookie },
+      });
+      assert.equal(oversized.statusCode, 400, oversized.body);
+      assert.equal(oversized.json().code, "ORDER_CURSOR_INVALID");
+
+      await insertRows("CURSOR-BUDGET-", 2_749);
+      const large = await readPage("CURSOR-BUDGET-");
+      assert.ok(Math.abs(large.reads - first.reads) <= 1, `规模增长前后读取次数差应不超过 1：${first.reads} -> ${large.reads}`);
+      await assertListPlanHasNoPerRowEventScan();
+    } finally {
+      await app.close();
+      await pool.end();
+      await setup.end();
+    }
   });
 });
 

--- a/apps/api/src/modules/performance.ts
+++ b/apps/api/src/modules/performance.ts
@@ -36,6 +36,39 @@ const groupAchievementQuerySchema = dashboardQuerySchema.extend({
 const departmentAchievementQuerySchema = dashboardQuerySchema.extend({
   departmentId: z.coerce.number().int().positive(),
 });
+const ORDER_PAGE_SIZE = 50;
+const orderListQuerySchema = z.object({
+  search: z.string().trim().max(100).optional(),
+  cursor: z.string().min(1).max(2048).optional(),
+});
+const postgresBigintIdSchema = z.string().refine(
+  (value) => /^[1-9]\d*$/.test(value) && BigInt(value) <= 9_223_372_036_854_775_807n,
+);
+const orderCursorSchema = z.strictObject({
+  version: z.literal(1),
+  direction: z.enum(["next", "previous"]),
+  anchorCreatedAt: z.iso.datetime(),
+  anchorId: postgresBigintIdSchema,
+  cutoffCreatedAt: z.iso.datetime(),
+  cutoffId: postgresBigintIdSchema,
+  search: z.string().max(100),
+  userId: postgresBigintIdSchema,
+});
+type OrderCursor = z.infer<typeof orderCursorSchema>;
+
+function encodeOrderCursor(cursor: OrderCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeOrderCursor(value: string): OrderCursor | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  try {
+    const parsed = orderCursorSchema.safeParse(JSON.parse(Buffer.from(value, "base64url").toString("utf8")));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
 
 const DEPARTMENT_ACHIEVEMENT_ROLES = ["sales_supervisor", "sales_manager", "hr", "general_manager"] as const;
 const SALES_ACHIEVEMENT_ROLES = ["sales_manager", "hr", "general_manager"] as const;
@@ -939,11 +972,18 @@ export async function registerPerformance(app: FastifyInstance, db: Database, cl
     if (!request.currentUser) return reply.code(401).send({ message: "尚未登录" });
     const access = await resolvePerformanceAccess(db, request.currentUser);
     if (!canReadPerformance(access)) return reply.code(403).send({ message: "当前角色没有业务查看权限" });
-    const query = z.object({ search: z.string().trim().max(100).optional(), limit: z.coerce.number().int().min(1).max(100).default(30) }).safeParse(request.query);
+    const query = orderListQuerySchema.safeParse(request.query);
     if (!query.success) return reply.code(400).send({ message: "查询条件无效" });
-    const term = query.data.search ? `%${query.data.search}%` : null;
-    const result = await db.query(
-      `select id::text, qingflow_order_no as "orderNo", customer_name as "customerName",
+    const search = query.data.search ?? "";
+    const cursor = query.data.cursor ? decodeOrderCursor(query.data.cursor) : null;
+    if (query.data.cursor && (!cursor || cursor.search !== search || cursor.userId !== request.currentUser.id)) {
+      return reply.code(400).send({ code: "ORDER_CURSOR_INVALID", message: "分页游标无效或已不适用于当前查询" });
+    }
+    const term = search ? `%${search}%` : null;
+    const direction = cursor?.direction ?? "next";
+    type OrderListRow = Record<string, unknown> & { id: string; __cursorCreatedAt: Date };
+    const result = await db.query<OrderListRow>(
+      `select id::text, created_at as "__cursorCreatedAt", qingflow_order_no as "orderNo", customer_name as "customerName",
               customer_unit as "customerUnit", performance_orders.salesperson_name as "salespersonName", service_type as "serviceType",
               source_received_on as "sourceReceivedOn", original_amount::text as "originalAmount",
               current_revenue::text as "currentRevenue", counted_amount::text as "countedAmount",
@@ -951,13 +991,51 @@ export async function registerPerformance(app: FastifyInstance, db: Database, cl
               latest.department_name as "departmentName", latest.group_name as "groupName",
               latest.leader_name as "leaderName", latest.supervisor_name as "supervisorName"
        from performance_orders
-       left join lateral (select salesperson_person_id,department_unit_id,group_unit_id,salesperson_name,department_name,group_name,leader_name,supervisor_name from performance_events where order_id=performance_orders.id order by occurred_on desc,id desc limit 1) latest on true
-       where ($1::text is null or performance_orders.qingflow_order_no ilike $1 or performance_orders.salesperson_name ilike $1 or performance_orders.customer_name ilike $1)
+       left join (
+         select distinct on (order_id) order_id,salesperson_person_id,department_unit_id,group_unit_id,
+                salesperson_name,department_name,group_name,leader_name,supervisor_name
+         from performance_events order by order_id,occurred_on desc,id desc
+       ) latest on latest.order_id=performance_orders.id
+       where ($1::text is null or performance_orders.qingflow_order_no ilike $1 or performance_orders.salesperson_name ilike $1 or performance_orders.customer_name ilike $1 or performance_orders.customer_unit ilike $1)
          and ${performanceScopeSql("latest", 3)}
-       order by posted_at desc nulls last, id desc limit $2`,
-      [term, query.data.limit, ...performanceScopeValues(access)],
+         ${cursor ? `and (performance_orders.created_at,performance_orders.id)<=($7::timestamptz,$8::bigint)
+         and (performance_orders.created_at,performance_orders.id)${direction === "next" ? "<" : ">"}($9::timestamptz,$10::bigint)` : ""}
+       order by performance_orders.created_at ${direction === "previous" ? "asc" : "desc"},performance_orders.id ${direction === "previous" ? "asc" : "desc"}
+       limit $2`,
+      [
+        term,
+        ORDER_PAGE_SIZE + 1,
+        ...performanceScopeValues(access),
+        ...(cursor ? [cursor.cutoffCreatedAt, cursor.cutoffId, cursor.anchorCreatedAt, cursor.anchorId] : []),
+      ],
     );
-    return { orders: result.rows };
+    const hasExtra = result.rows.length > ORDER_PAGE_SIZE;
+    const pageRows = result.rows.slice(0, ORDER_PAGE_SIZE);
+    if (direction === "previous") pageRows.reverse();
+    const cutoff = cursor ?? (pageRows[0] ? {
+      cutoffCreatedAt: pageRows[0].__cursorCreatedAt.toISOString(),
+      cutoffId: pageRows[0].id,
+    } : null);
+    const makeCursor = (cursorDirection: OrderCursor["direction"], anchor: OrderListRow): string => encodeOrderCursor({
+      version: 1,
+      direction: cursorDirection,
+      anchorCreatedAt: anchor.__cursorCreatedAt.toISOString(),
+      anchorId: anchor.id,
+      cutoffCreatedAt: cutoff!.cutoffCreatedAt,
+      cutoffId: cutoff!.cutoffId,
+      search,
+      userId: request.currentUser!.id,
+    });
+    const first = pageRows[0];
+    const last = pageRows.at(-1);
+    const previousCursor = first && cursor && (cursor.direction === "next" || hasExtra) ? makeCursor("previous", first) : null;
+    const nextCursor = last && (cursor?.direction === "previous" || hasExtra) ? makeCursor("next", last) : null;
+    return {
+      orders: pageRows.map(({ __cursorCreatedAt: _createdAt, ...order }) => order),
+      previousCursor,
+      nextCursor,
+      pageSize: ORDER_PAGE_SIZE,
+    };
   });
 
   app.get("/api/performance/orders/:id/events", async (request, reply) => {

--- a/apps/api/src/test-database.integration.test.ts
+++ b/apps/api/src/test-database.integration.test.ts
@@ -75,6 +75,7 @@ test("干净隔离数据库可应用全部现有迁移", async () => {
         "016_goal_governance.sql",
         "017_controlled_performance_import.sql",
         "018_add_import_reconciliation.sql",
+        "019_performance_order_cursor.sql",
       ]);
     } finally {
       await client.end();

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -88,6 +88,83 @@ test("销售助理组长可用标准模板预检并确认整批入账", async ({
       await expect(page.getByRole("heading",{name:"Excel 批量导入"})).toBeHidden();await expect(page.getByText("001-A",{exact:true})).toBeVisible();
 });
 
+test("订单台账以前后游标稳定浏览并在刷新后开启新快照", async ({ database, page }) => {
+  const userId = await seedTestUser(database.url, {
+    username: "e2e_cursor_assistant",
+    displayName: "E2E 游标销售助理",
+    password: "Cursor@123",
+    roleCode: "sales_assistant",
+    roleName: "销售助理",
+  });
+  const setup = new Client({ connectionString: database.url });
+  await setup.connect();
+  const person = await setup.query<{ id: string }>("select id::text from people where user_id=$1", [userId]);
+  async function insertRows(prefix: string, count: number) {
+    await setup.query(
+      `with orders as (
+         insert into performance_orders
+           (qingflow_order_no,customer_name,customer_unit,salesperson_person_id,salesperson_name,
+            source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,created_at,posted_at)
+         select $1||lpad(series::text,4,'0'),'E2E游标客户'||lpad(series::text,4,'0'),
+                'E2E游标单位'||lpad(series::text,4,'0'),$3,'E2E 游标业务员','2026-08-31',1,1,1,'active',$4,$4
+         from generate_series(1,$2::integer) series returning id
+       )
+       insert into performance_events
+         (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,
+          accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,department_name,group_name)
+       select id,'initial',1,1,1,'2026-08-01','2026-08-31','浏览器游标回归',$3,'E2E 游标业务员','E2E 部门','E2E 小组'
+       from orders`,
+      [prefix, count, person.rows[0]!.id, "2026-08-31T12:00:00.000Z"],
+    );
+  }
+  await insertRows("E2E-CURSOR-", 101);
+
+  try {
+    await page.goto("/");
+    await page.getByLabel("账号").fill("e2e_cursor_assistant");
+    await page.getByLabel("密码", { exact: true }).fill("Cursor@123");
+    await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+    await page.getByRole("button", { name: "订单业绩", exact: true }).click();
+    const ledger = page.locator("section.orders-card").filter({ has: page.getByRole("heading", { name: "订单台账" }) });
+    await expect(ledger.getByText("本页 50 笔订单", { exact: true })).toBeVisible();
+    await expect(ledger.getByText("E2E-CURSOR-0101", { exact: true })).toBeVisible();
+    await expect(ledger.getByRole("button", { name: "上一页" })).toBeDisabled();
+    await expect(ledger.getByRole("button", { name: "下一页" })).toBeEnabled();
+
+    await insertRows("E2E-CURSOR-NEW-", 1);
+    let failNextPage = true;
+    await page.route("**/api/performance/orders?cursor=*", async (route) => {
+      if (failNextPage) {
+        failNextPage = false;
+        await route.fulfill({ status: 503, contentType: "application/json", body: '{"message":"分页暂时失败"}' });
+        return;
+      }
+      await route.continue();
+    });
+    await ledger.getByRole("button", { name: "下一页" }).click();
+    await expect(page.getByText("分页暂时失败", { exact: true })).toBeVisible();
+    await ledger.getByRole("button", { name: "下一页" }).click();
+    await expect(ledger.getByText("E2E-CURSOR-0051", { exact: true })).toBeVisible();
+    await ledger.getByRole("button", { name: "下一页" }).click();
+    await expect(ledger.getByText("E2E-CURSOR-0001", { exact: true })).toBeVisible();
+    await expect(ledger.getByText("本页 1 笔订单", { exact: true })).toBeVisible();
+    await expect(ledger.getByRole("button", { name: "下一页" })).toBeDisabled();
+    await ledger.getByRole("button", { name: "上一页" }).click();
+    await expect(ledger.getByText("E2E-CURSOR-0051", { exact: true })).toBeVisible();
+    await ledger.getByRole("button", { name: "上一页" }).click();
+    await expect(ledger.getByText("E2E-CURSOR-0101", { exact: true })).toBeVisible();
+    await expect(ledger.getByText("E2E-CURSOR-NEW-0001", { exact: true })).toHaveCount(0);
+
+    await ledger.getByRole("button", { name: "刷新订单" }).click();
+    await expect(ledger.getByText("E2E-CURSOR-NEW-0001", { exact: true })).toBeVisible();
+    await page.getByLabel("定位订单").fill("E2E游标单位0042");
+    await expect(ledger.getByText("E2E-CURSOR-0042", { exact: true })).toBeVisible();
+    await expect(ledger.getByText("本页 1 笔订单", { exact: true })).toBeVisible();
+  } finally {
+    await setup.end();
+  }
+});
+
 test("首次登录用户看到密码强度并完成改密", async ({ database, page }) => {
     await seedTestUser(database.url, {
       username: "e2e_password_change",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -300,6 +300,9 @@ function OrdersPage({ user }: { user: User }) {
   const [isComposing, setIsComposing] = useState(false);
   const [loading, setLoading] = useState(true);
   const [refreshVersion, setRefreshVersion] = useState(0);
+  const [pageCursor, setPageCursor] = useState<string | null>(null);
+  const [previousCursor, setPreviousCursor] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const commitSearch = useCallback((value:string, historyMode:"push"|"replace"="push") => {
     const normalized=value.trim();
@@ -307,10 +310,11 @@ function OrdersPage({ user }: { user: User }) {
     if(normalized)params.set("orderSearch",normalized);else params.delete("orderSearch");
     const next=`${window.location.pathname}${params.size?`?${params.toString()}`:""}${window.location.hash}`;
     window.history[historyMode==="push"?"pushState":"replaceState"]({},"",next);
+    setPageCursor(null);
     setCommittedSearch(normalized);
   },[]);
   useEffect(()=>{
-    const restore=()=>{const value=new URLSearchParams(window.location.search).get("orderSearch")??"";setSearch(value);setCommittedSearch(value);};
+    const restore=()=>{const value=new URLSearchParams(window.location.search).get("orderSearch")??"";setSearch(value);setPageCursor(null);setCommittedSearch(value);};
     window.addEventListener("popstate",restore);return()=>window.removeEventListener("popstate",restore);
   },[]);
   useEffect(()=>{
@@ -320,24 +324,27 @@ function OrdersPage({ user }: { user: User }) {
   },[search,isComposing,committedSearch,commitSearch]);
   useEffect(() => {
     const controller=new AbortController();setLoading(true);setMessage("");
-    const params=new URLSearchParams({limit:"100"});if(committedSearch)params.set("search",committedSearch);
+    const params=new URLSearchParams();if(committedSearch)params.set("search",committedSearch);if(pageCursor)params.set("cursor",pageCursor);
     fetch(`/api/performance/orders?${params.toString()}`,{signal:controller.signal}).then(async(response)=>{
-      const data=await response.json() as {orders?:Order[];message?:string};
+      const data=await response.json() as {orders?:Order[];previousCursor?:string|null;nextCursor?:string|null;message?:string};
       if(!response.ok)throw new Error(data.message??"订单加载失败");
       setOrders(data.orders??[]);
+      setPreviousCursor(data.previousCursor??null);setNextCursor(data.nextCursor??null);
     }).catch((error)=>{if(error instanceof DOMException&&error.name==="AbortError")return;setMessage(error instanceof Error?error.message:"订单加载失败");})
       .finally(()=>{if(!controller.signal.aborted)setLoading(false);});
     return()=>controller.abort();
-  }, [committedSearch,refreshVersion]);
-  async function refresh() { setRefreshVersion((value)=>value+1); }
+  }, [committedSearch,pageCursor,refreshVersion]);
+  async function refresh() { setPageCursor(null);setRefreshVersion((value)=>value+1); }
+  function movePage(cursor:string|null){if(!cursor)return;if(cursor===pageCursor)setRefreshVersion((value)=>value+1);else setPageCursor(cursor);}
   function clearSearch(){setSearch("");commitSearch("");window.requestAnimationFrame(()=>searchRef.current?.focus());}
   return <main className="dashboard orders-page"><header><div><h1>订单业绩</h1><p>按订单编号维护不可变业绩事件；已入账记录不能覆盖或删除</p></div>{canEdit ? <div className="header-actions"><button className="secondary-action" onClick={() => setShowImport(true)}><FileUp size={16}/>Excel 导入</button><button className="primary-action" onClick={() => setShowCreate(true)}><Plus size={16}/>录入新订单</button></div> : null}</header>
     {message ? <p className="page-message" role="status">{message}</p> : null}
     {!canEdit ? <div className="permission-note"><ShieldCheck size={18}/>当前角色仅可查看。只有销售助理及销售助理组长可以录入或调整业绩。</div> : null}
     <LedgerGovernancePanel user={user} orders={orders} onChanged={refresh}/>
-    <section className="orders-card" aria-labelledby="orders-table-title"><div className="orders-toolbar"><div><h2 id="orders-table-title">订单台账</h2><span role="status">{loading?"正在查询…":`${orders.length} 笔订单`}</span></div><button className="icon-action" onClick={() => refresh()} aria-label="刷新订单"><RefreshCw size={17}/></button></div>
-      <form className="order-search" role="search" noValidate onSubmit={(event)=>{event.preventDefault();if(!isComposing)commitSearch(search);}}><label htmlFor="order-search-input">定位订单</label><div><Search size={17} aria-hidden="true"/><input ref={searchRef} id="order-search-input" type="search" value={search} placeholder="输入订单编号、客户或业务员" onChange={(event)=>setSearch(event.target.value)} onCompositionStart={()=>setIsComposing(true)} onCompositionEnd={(event)=>{setIsComposing(false);setSearch(event.currentTarget.value);}}/>{search?<button type="button" onClick={clearSearch} aria-label="清除订单搜索"><X size={16}/></button>:null}</div><button type="submit">搜索</button></form>
+    <section className="orders-card" aria-labelledby="orders-table-title"><div className="orders-toolbar"><div><h2 id="orders-table-title">订单台账</h2><span role="status">{loading?"正在查询…":`本页 ${orders.length} 笔订单`}</span></div><button className="icon-action" onClick={() => refresh()} aria-label="刷新订单"><RefreshCw size={17}/></button></div>
+      <form className="order-search" role="search" noValidate onSubmit={(event)=>{event.preventDefault();if(!isComposing)commitSearch(search);}}><label htmlFor="order-search-input">定位订单</label><div><Search size={17} aria-hidden="true"/><input ref={searchRef} id="order-search-input" type="search" value={search} placeholder="输入订单编号、客户名称、客户单位或业务员" onChange={(event)=>setSearch(event.target.value)} onCompositionStart={()=>setIsComposing(true)} onCompositionEnd={(event)=>{setIsComposing(false);setSearch(event.currentTarget.value);}}/>{search?<button type="button" onClick={clearSearch} aria-label="清除订单搜索"><X size={16}/></button>:null}</div><button type="submit">搜索</button></form>
       <div className="orders-table-wrap"><table><thead><tr><th scope="col">订单编号</th><th scope="col">客户</th><th scope="col">业务员</th><th scope="col">当前营业额</th><th scope="col">计入业绩</th><th scope="col">状态</th><th scope="col">操作</th></tr></thead><tbody>{!loading&&orders.length === 0 ? <tr><td colSpan={7} className="empty-cell">{committedSearch?`没有找到与“${committedSearch}”匹配的订单。`:"暂无订单，请录入第一笔业绩。"}</td></tr> : orders.map((order) => <tr key={order.id}><td>{order.orderNo}</td><td>{order.customerName}</td><td>{order.salespersonName}</td><td>{formatMoney(order.currentRevenue)}</td><td>{formatMoney(order.countedAmount)}</td><td><Status state={order.lifecycleState}/></td><td><button className="table-action" onClick={() => setSelected(order)}>查看 / 调整</button></td></tr>)}</tbody></table></div>
+      <nav className="table-pagination" aria-label="订单分页"><button type="button" disabled={loading||!previousCursor} onClick={()=>movePage(previousCursor)}>上一页</button><button type="button" disabled={loading||!nextCursor} onClick={()=>movePage(nextCursor)}>下一页</button></nav>
     </section>
     {showCreate ? <CreateOrder onClose={() => setShowCreate(false)} onSaved={async () => { setShowCreate(false); await refresh(); }} /> : null}
     {showImport ? <ExcelImportDialog user={user} onClose={() => setShowImport(false)} onImported={async () => { setShowImport(false); await refresh(); }} /> : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -363,6 +363,9 @@ th { color: #68778a; background: #fafbfc; font-weight: 600; }
 .order-search input::-webkit-search-cancel-button { appearance: none; }
 .order-search > div > button { position: absolute; top: 4px; right: 4px; width: 32px; height: 32px; margin: 0; padding: 0; border: 0; color: #64758a; background: transparent; display: grid; place-items: center; }
 .order-search > button { width: auto; height: 40px; margin: 0; padding: 0 17px; border: 1px solid var(--blue); color: #fff; background: var(--blue); }
+.table-pagination { padding: 14px 20px; border-top: 1px solid var(--line); display: flex; justify-content: flex-end; gap: 8px; }
+.table-pagination button { width: auto; height: 36px; margin: 0; padding: 0 14px; border: 1px solid var(--line); border-radius: 6px; color: #39495d; background: #fff; }
+.table-pagination button:disabled { color: #9aa6b5; background: #f4f5f7; cursor: not-allowed; }
 .event-ledger { padding: 20px 24px 4px; }
 .event-ledger-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
 .event-ledger-heading h3 { margin: 0; color: var(--navy); font-size: 15px; }


### PR DESCRIPTION
Closes #42

## 实现
- 服务端固定每页 50 条，以不可变创建时间和 ID 做稳定游标排序
- 首次请求冻结快照上界，支持同权限口径的上一页/下一页
- 搜索覆盖订单编号、客户名称、客户单位和业务员
- Web 增加可访问的前后分页与刷新重启快照
- 新增游标索引、完整遍历/权限/查询上界回归及浏览器验收

## 验证
- `npm.cmd run verify`
- API 131/131
- Playwright 15/15
- 类型检查、生产构建、依赖审计（0 漏洞）及 Compose 配置通过