### PR TITLE
[P1][TB-07] URL 组合筛选与返回恢复

### DIFF
--- a/apps/api/src/authorization.integration.test.ts
+++ b/apps/api/src/authorization.integration.test.ts
@@ -1331,6 +1331,12 @@ test("订单台账用固定快照稳定遍历并保持有界查询次数", async
         headers: { cookie: leaderCookie },
       });
       assert.equal(mismatch.statusCode, 400, mismatch.body);
+      const filterMismatch = await app.inject({
+        method: "GET",
+        url: `/api/performance/orders?search=CURSOR-FIX-&status=active&cursor=${encodeURIComponent(first.body.nextCursor!)}`,
+        headers: { cookie: leaderCookie },
+      });
+      assert.equal(filterMismatch.statusCode, 400, filterMismatch.body);
       const bobCookie = await loginCookie(app, "scope_bob");
       const otherUser = await app.inject({
         method: "GET",
@@ -1358,6 +1364,106 @@ test("订单台账用固定快照稳定遍历并保持有界查询次数", async
       await pool.end();
       await setup.end();
     }
+  });
+});
+
+test("订单组合筛选始终叠加服务端权限范围", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    const scenario = await seedAuthorizationScenario(database.url);
+    const maximumTextFilter = "筛".repeat(300);
+    const maximumSearch = "S".repeat(100);
+    const setup = new Client({ connectionString: database.url });
+    await setup.connect();
+    try {
+      await setup.query(
+        `update performance_orders set
+           customer_unit=case qingflow_order_no when 'SCOPE-1' then '甲客户单位' when 'SCOPE-2' then '乙客户单位' else '丙客户单位' end,
+           business_region_code=case qingflow_order_no when 'SCOPE-1' then 'CN-JS' when 'SCOPE-2' then 'CN-ZJ' else 'EXT-TRADE' end,
+           source_received_on=case qingflow_order_no when 'SCOPE-2' then '2026-09-01'::date else '2026-08-01'::date end,
+           lifecycle_state=case qingflow_order_no when 'SCOPE-2' then 'paused' else 'active' end
+         where id=any($1::bigint[])`,
+        [scenario.orderIds],
+      );
+      await setup.query(
+        `with source as (
+           select salesperson_person_id,department_unit_id,group_unit_id,leader_person_id,supervisor_person_id
+           from performance_events where order_id=$1 limit 1
+         ), orders as (
+           insert into performance_orders
+             (qingflow_order_no,customer_name,customer_unit,business_region_code,salesperson_person_id,salesperson_name,
+              source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,created_at,posted_at)
+           select $2||series::text,'最长筛选客户',$3,'CN-JS',source.salesperson_person_id,$3,
+                  '2026-08-15',1,1,1,'active','2026-08-31T14:00:00Z','2026-08-31T14:00:00Z'
+           from source cross join generate_series(1,51) series returning id
+         )
+         insert into performance_events
+           (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,
+            accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,
+            department_unit_id,department_name,group_unit_id,group_name,leader_person_id,leader_name,
+            supervisor_person_id,supervisor_name)
+         select orders.id,'initial',1,1,1,'2026-08-01','2026-08-15','最长筛选游标回归',
+                source.salesperson_person_id,$3,source.department_unit_id,$3,source.group_unit_id,$3,
+                source.leader_person_id,'最长筛选组长',source.supervisor_person_id,'最长筛选主管'
+         from orders cross join source`,
+        [scenario.orderIds[0], maximumSearch, maximumTextFilter],
+      );
+    } finally {
+      await setup.end();
+    }
+
+    await withTestApi(database.url, async (app) => {
+      const leaderCookie = await loginCookie(app, "scope_leader");
+      const filters = new URLSearchParams({
+        search: "SCOPE-",
+        month: "2026-08",
+        status: "active",
+        salesperson: "业务员甲",
+        department: "甲部",
+        group: "甲组",
+        region: "CN-JS",
+        customerUnit: "甲客户单位",
+      });
+      const matched = await app.inject({ method: "GET", url: `/api/performance/orders?${filters}`, headers: { cookie: leaderCookie } });
+      assert.equal(matched.statusCode, 200, matched.body);
+      assert.deepEqual((matched.json().orders as Array<{ orderNo: string }>).map((order) => order.orderNo), ["SCOPE-1"]);
+
+      filters.set("group", "乙组");
+      const empty = await app.inject({ method: "GET", url: `/api/performance/orders?${filters}`, headers: { cookie: leaderCookie } });
+      assert.equal(empty.statusCode, 200, empty.body);
+      assert.deepEqual(empty.json().orders, []);
+
+      const forged = await app.inject({ method: "GET", url: "/api/performance/orders?department=乙部", headers: { cookie: leaderCookie } });
+      assert.equal(forged.statusCode, 200, forged.body);
+      assert.deepEqual(forged.json().orders, []);
+      const assistantCookie = await loginCookie(app, "scope_assistant");
+      const authorized = await app.inject({ method: "GET", url: "/api/performance/orders?department=乙部", headers: { cookie: assistantCookie } });
+      assert.equal(authorized.statusCode, 200, authorized.body);
+      assert.deepEqual((authorized.json().orders as Array<{ orderNo: string }>).map((order) => order.orderNo), ["SCOPE-3"]);
+
+      for (const query of ["month=2026-13", "status=forged"]) {
+        const invalid = await app.inject({ method: "GET", url: `/api/performance/orders?${query}`, headers: { cookie: leaderCookie } });
+        assert.equal(invalid.statusCode, 400, invalid.body);
+      }
+
+      const maximumFilters = new URLSearchParams({
+        search: maximumSearch,
+        month: "2026-08",
+        status: "active",
+        salesperson: maximumTextFilter,
+        department: maximumTextFilter,
+        group: maximumTextFilter,
+        region: "CN-JS",
+        customerUnit: maximumTextFilter,
+      });
+      const maximumFirst = await app.inject({ method: "GET", url: `/api/performance/orders?${maximumFilters}`, headers: { cookie: leaderCookie } });
+      assert.equal(maximumFirst.statusCode, 200, maximumFirst.body);
+      assert.equal(maximumFirst.json().orders.length, 50);
+      assert.ok(maximumFirst.json().nextCursor.length < 2048);
+      maximumFilters.set("cursor", maximumFirst.json().nextCursor);
+      const maximumSecond = await app.inject({ method: "GET", url: `/api/performance/orders?${maximumFilters}`, headers: { cookie: leaderCookie } });
+      assert.equal(maximumSecond.statusCode, 200, maximumSecond.body);
+      assert.equal(maximumSecond.json().orders.length, 1);
+    });
   });
 });
 

--- a/apps/api/src/modules/performance.ts
+++ b/apps/api/src/modules/performance.ts
@@ -37,24 +37,47 @@ const departmentAchievementQuerySchema = dashboardQuerySchema.extend({
   departmentId: z.coerce.number().int().positive(),
 });
 const ORDER_PAGE_SIZE = 50;
-const orderListQuerySchema = z.object({
-  search: z.string().trim().max(100).optional(),
-  cursor: z.string().min(1).max(2048).optional(),
-});
 const postgresBigintIdSchema = z.string().refine(
   (value) => /^[1-9]\d*$/.test(value) && BigInt(value) <= 9_223_372_036_854_775_807n,
 );
+const orderTextFilterSchema = z.string().trim().min(1).max(300);
+const orderListQuerySchema = z.object({
+  search: z.string().trim().max(100).optional(),
+  month: z.string().regex(/^[1-9]\d{3}-(0[1-9]|1[0-2])$/).optional(),
+  status: z.enum(["draft", "active", "paused", "zero", "historical_review_required"]).optional(),
+  salesperson: orderTextFilterSchema.optional(),
+  department: orderTextFilterSchema.optional(),
+  group: orderTextFilterSchema.optional(),
+  region: z.string().refine((value) => standardBusinessRegionName(value) !== undefined).optional(),
+  customerUnit: orderTextFilterSchema.optional(),
+  cursor: z.string().min(1).max(2048).optional(),
+});
+const orderCursorFiltersSchema = z.strictObject({
+  search: z.string().max(100),
+  month: z.string().max(7),
+  status: z.string().max(40),
+  salesperson: z.string().max(300),
+  department: z.string().max(300),
+  group: z.string().max(300),
+  region: z.string().max(20),
+  customerUnit: z.string().max(300),
+});
 const orderCursorSchema = z.strictObject({
-  version: z.literal(1),
+  version: z.literal(2),
   direction: z.enum(["next", "previous"]),
   anchorCreatedAt: z.iso.datetime(),
   anchorId: postgresBigintIdSchema,
   cutoffCreatedAt: z.iso.datetime(),
   cutoffId: postgresBigintIdSchema,
-  search: z.string().max(100),
+  filterDigest: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
   userId: postgresBigintIdSchema,
 });
+type OrderCursorFilters = z.infer<typeof orderCursorFiltersSchema>;
 type OrderCursor = z.infer<typeof orderCursorSchema>;
+
+function orderFilterDigest(filters: OrderCursorFilters): string {
+  return createHash("sha256").update(JSON.stringify(filters), "utf8").digest("base64url");
+}
 
 function encodeOrderCursor(cursor: OrderCursor): string {
   return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
@@ -974,12 +997,21 @@ export async function registerPerformance(app: FastifyInstance, db: Database, cl
     if (!canReadPerformance(access)) return reply.code(403).send({ message: "当前角色没有业务查看权限" });
     const query = orderListQuerySchema.safeParse(request.query);
     if (!query.success) return reply.code(400).send({ message: "查询条件无效" });
-    const search = query.data.search ?? "";
+    const filters: OrderCursorFilters = {
+      search: query.data.search ?? "",
+      month: query.data.month ?? "",
+      status: query.data.status ?? "",
+      salesperson: query.data.salesperson ?? "",
+      department: query.data.department ?? "",
+      group: query.data.group ?? "",
+      region: query.data.region ?? "",
+      customerUnit: query.data.customerUnit ?? "",
+    };
     const cursor = query.data.cursor ? decodeOrderCursor(query.data.cursor) : null;
-    if (query.data.cursor && (!cursor || cursor.search !== search || cursor.userId !== request.currentUser.id)) {
+    if (query.data.cursor && (!cursor || cursor.filterDigest !== orderFilterDigest(filters) || cursor.userId !== request.currentUser.id)) {
       return reply.code(400).send({ code: "ORDER_CURSOR_INVALID", message: "分页游标无效或已不适用于当前查询" });
     }
-    const term = search ? `%${search}%` : null;
+    const term = filters.search ? `%${filters.search}%` : null;
     const direction = cursor?.direction ?? "next";
     type OrderListRow = Record<string, unknown> & { id: string; __cursorCreatedAt: Date };
     const result = await db.query<OrderListRow>(
@@ -998,14 +1030,28 @@ export async function registerPerformance(app: FastifyInstance, db: Database, cl
        ) latest on latest.order_id=performance_orders.id
        where ($1::text is null or performance_orders.qingflow_order_no ilike $1 or performance_orders.salesperson_name ilike $1 or performance_orders.customer_name ilike $1 or performance_orders.customer_unit ilike $1)
          and ${performanceScopeSql("latest", 3)}
-         ${cursor ? `and (performance_orders.created_at,performance_orders.id)<=($7::timestamptz,$8::bigint)
-         and (performance_orders.created_at,performance_orders.id)${direction === "next" ? "<" : ">"}($9::timestamptz,$10::bigint)` : ""}
+         and ($7::date is null or (performance_orders.source_received_on >= $7::date and performance_orders.source_received_on < $7::date + interval '1 month'))
+         and ($8::text is null or performance_orders.lifecycle_state=$8)
+         and ($9::text is null or performance_orders.salesperson_name=$9)
+         and ($10::text is null or latest.department_name=$10)
+         and ($11::text is null or latest.group_name=$11)
+         and ($12::text is null or performance_orders.business_region_code=$12)
+         and ($13::text is null or performance_orders.customer_unit=$13)
+         ${cursor ? `and (performance_orders.created_at,performance_orders.id)<=($14::timestamptz,$15::bigint)
+         and (performance_orders.created_at,performance_orders.id)${direction === "next" ? "<" : ">"}($16::timestamptz,$17::bigint)` : ""}
        order by performance_orders.created_at ${direction === "previous" ? "asc" : "desc"},performance_orders.id ${direction === "previous" ? "asc" : "desc"}
        limit $2`,
       [
         term,
         ORDER_PAGE_SIZE + 1,
         ...performanceScopeValues(access),
+        filters.month ? `${filters.month}-01` : null,
+        filters.status || null,
+        filters.salesperson || null,
+        filters.department || null,
+        filters.group || null,
+        filters.region || null,
+        filters.customerUnit || null,
         ...(cursor ? [cursor.cutoffCreatedAt, cursor.cutoffId, cursor.anchorCreatedAt, cursor.anchorId] : []),
       ],
     );
@@ -1017,13 +1063,13 @@ export async function registerPerformance(app: FastifyInstance, db: Database, cl
       cutoffId: pageRows[0].id,
     } : null);
     const makeCursor = (cursorDirection: OrderCursor["direction"], anchor: OrderListRow): string => encodeOrderCursor({
-      version: 1,
+      version: 2,
       direction: cursorDirection,
       anchorCreatedAt: anchor.__cursorCreatedAt.toISOString(),
       anchorId: anchor.id,
       cutoffCreatedAt: cutoff!.cutoffCreatedAt,
       cutoffId: cutoff!.cutoffId,
-      search,
+      filterDigest: orderFilterDigest(filters),
       userId: request.currentUser!.id,
     });
     const first = pageRows[0];

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -165,6 +165,153 @@ test("订单台账以前后游标稳定浏览并在刷新后开启新快照", as
   }
 });
 
+test("订单组合筛选由 URL 恢复并区分空集、失败和无权限", async ({ database, page }) => {
+  const userId = await seedTestUser(database.url, {
+    username: "e2e_filter_assistant",
+    displayName: "E2E 筛选销售助理",
+    password: "Filter@123",
+    roleCode: "sales_assistant",
+    roleName: "销售助理",
+  });
+  const setup = new Client({ connectionString: database.url });
+  await setup.connect();
+  const person = await setup.query<{ id: string }>("select id::text from people where user_id=$1", [userId]);
+  async function insertRows(prefix: string, count: number, values: {
+    customerUnit: string;
+    salesperson: string;
+    month: string;
+    status: string;
+    region: string;
+    department: string;
+    group: string;
+  }) {
+    await setup.query(
+      `with orders as (
+         insert into performance_orders
+           (qingflow_order_no,customer_name,customer_unit,business_region_code,salesperson_person_id,salesperson_name,
+            source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,created_at,posted_at)
+         select $1||lpad(series::text,4,'0'),'E2E 筛选客户',$3,$7,$4,$5,($6::text||'-15')::date,1,1,1,$8,$11,$11
+         from generate_series(1,$2::integer) series returning id
+       )
+       insert into performance_events
+         (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,
+          accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,department_name,group_name)
+       select id,'initial',1,1,1,($6::text||'-01')::date,($6::text||'-15')::date,'浏览器组合筛选回归',$4,$5,$9,$10 from orders`,
+      [
+        prefix,
+        count,
+        values.customerUnit,
+        person.rows[0]!.id,
+        values.salesperson,
+        values.month,
+        values.region,
+        values.status,
+        values.department,
+        values.group,
+        "2026-08-31T13:00:00.000Z",
+      ],
+    );
+  }
+  const matching = {
+    customerUnit: "筛选单位甲",
+    salesperson: "筛选业务员甲",
+    month: "2026-08",
+    status: "active",
+    region: "CN-JS",
+    department: "筛选甲部",
+    group: "筛选甲组",
+  };
+  await insertRows("E2E-FILTER-", 51, matching);
+  await insertRows("E2E-OTHER-", 1, { ...matching, customerUnit: "筛选单位乙", region: "CN-ZJ" });
+
+  try {
+    await page.goto("/");
+    await page.getByLabel("账号").fill("e2e_filter_assistant");
+    await page.getByLabel("密码", { exact: true }).fill("Filter@123");
+    await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+    await page.getByRole("button", { name: "订单业绩", exact: true }).click();
+    const ledger = page.locator("section.orders-card").filter({ has: page.getByRole("heading", { name: "订单台账" }) });
+
+    await page.getByLabel("订单月份").fill(matching.month);
+    await page.getByLabel("部门筛选").fill(matching.department);
+    await page.getByLabel("定位订单").fill("E2E-FILTER-");
+    await expect(page).toHaveURL(/orderSearch=E2E-FILTER-/);
+    await expect(page.getByLabel("订单月份")).toHaveValue(matching.month);
+    await expect(page.getByLabel("部门筛选")).toHaveValue(matching.department);
+    await page.getByLabel("订单状态").selectOption(matching.status);
+    await page.getByLabel("业务员筛选").fill(matching.salesperson);
+    await page.getByLabel("小组筛选").fill(matching.group);
+    await page.getByLabel("标准业务区域筛选").selectOption(matching.region);
+    await page.getByLabel("客户单位筛选").fill(matching.customerUnit);
+    await page.getByRole("button", { name: "应用筛选" }).click();
+    await expect(ledger.getByText("E2E-FILTER-0051", { exact: true })).toBeVisible();
+    await expect(ledger.getByText("E2E-OTHER-0001", { exact: true })).toHaveCount(0);
+    await expect(page).toHaveURL(/page=orders/);
+    for (const value of ["orderMonth=2026-08", "orderStatus=active", "orderRegion=CN-JS"]) await expect(page).toHaveURL(new RegExp(value));
+
+    await ledger.getByRole("button", { name: "下一页" }).click();
+    await expect(ledger.getByText("E2E-FILTER-0001", { exact: true })).toBeVisible();
+    await expect(ledger.getByText("本页 1 笔订单", { exact: true })).toBeVisible();
+    const secondPageUrl = page.url();
+    expect(secondPageUrl).toContain("orderCursor=");
+    await page.reload();
+    await expect(ledger.getByText("E2E-FILTER-0001", { exact: true })).toBeVisible();
+    await ledger.getByRole("button", { name: "查看 / 调整" }).click();
+    await expect(page.getByRole("dialog", { name: "E2E-FILTER-0001" })).toBeVisible();
+    await page.getByRole("button", { name: "关闭" }).click();
+    expect(page.url()).toBe(secondPageUrl);
+
+    await page.goBack();
+    await expect(ledger.getByText("E2E-FILTER-0051", { exact: true })).toBeVisible();
+    await page.goForward();
+    await expect(ledger.getByText("E2E-FILTER-0001", { exact: true })).toBeVisible();
+
+    let responseMode: "live" | "empty" | "failure" | "forbidden" = "live";
+    await page.route("**/api/performance/orders*", async (route) => {
+      if (responseMode === "live") return route.continue();
+      if (responseMode === "failure") return route.fulfill({ status: 503, contentType: "application/json", body: '{"message":"筛选加载失败"}' });
+      if (responseMode === "forbidden") return route.fulfill({ status: 403, contentType: "application/json", body: '{"message":"当前角色没有业务查看权限"}' });
+      return route.fulfill({ status: 200, contentType: "application/json", body: '{"orders":[],"previousCursor":null,"nextCursor":null,"pageSize":50}' });
+    });
+    responseMode = "failure";
+    await page.getByLabel("客户单位筛选").fill("不存在的单位");
+    await page.getByRole("button", { name: "应用筛选" }).click();
+    await expect(page.getByRole("alert")).toHaveText("筛选加载失败");
+    await expect(ledger.getByText("E2E-FILTER-0001", { exact: true })).toHaveCount(0);
+    await expect(ledger.getByRole("button", { name: "上一页" })).toBeDisabled();
+    await expect(ledger.getByRole("button", { name: "下一页" })).toBeDisabled();
+    responseMode = "live";
+    await page.getByRole("button", { name: "重试查询" }).click();
+    await expect(ledger.getByText("没有符合当前组合条件的订单。", { exact: true })).toBeVisible();
+
+    responseMode = "empty";
+    await page.getByRole("button", { name: "清除筛选" }).click();
+    await expect(ledger.getByText("暂无订单数据。", { exact: true })).toBeVisible();
+    responseMode = "forbidden";
+    await ledger.getByRole("button", { name: "刷新订单" }).click();
+    await expect(page.getByText("当前账号没有订单查看权限。", { exact: true })).toBeVisible();
+  } finally {
+    await setup.end();
+  }
+});
+
+test("无业务权限账号访问订单深链时看到明确权限说明", async ({ database, page }) => {
+  await seedTestUser(database.url, {
+    username: "e2e_order_forbidden",
+    displayName: "E2E 纯系统管理员",
+    password: "Forbidden@123",
+    roleCode: "system_admin",
+    roleName: "系统管理员",
+  });
+  await page.goto("/?page=orders&orderMonth=2026-08");
+  await page.getByLabel("账号").fill("e2e_order_forbidden");
+  await page.getByLabel("密码", { exact: true }).fill("Forbidden@123");
+  await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+  await expect(page.getByRole("heading", { name: "无法访问订单业绩" })).toBeVisible();
+  await expect(page.getByText("当前账号没有订单查看权限。", { exact: true })).toBeVisible();
+  await expect(page).toHaveURL(/page=orders/);
+});
+
 test("首次登录用户看到密码强度并完成改密", async ({ database, page }) => {
     await seedTestUser(database.url, {
       username: "e2e_password_change",
@@ -501,12 +648,13 @@ test("系统管理员通过页面办理组织异动并保留前后有效期", as
       await page.getByRole("button",{name:"进入 SampleFlow"}).click();
       await page.getByRole("button",{name:"订单业绩",exact:true}).click();
       await page.getByRole("button",{name:"录入新订单"}).click();
+      const createOrderDialog=page.getByRole("dialog",{name:"录入订单业绩"});
       await page.getByLabel("订单编号").fill("ORG-TRANSFER-E2E-100");
       await page.getByLabel("收到日期").fill("2026-07-15");
       await page.getByLabel("客户名称").fill("组织异动客户");
-      await page.getByLabel("客户单位").fill("组织异动测试单位");
-      await page.getByLabel("业务区域").selectOption("EXT-TRADE");
-      await page.getByLabel("业务员").selectOption({label:"E2E 异动业务员"});
+      await page.getByLabel("客户单位",{exact:true}).fill("组织异动测试单位");
+      await createOrderDialog.getByLabel("业务区域").selectOption("EXT-TRADE");
+      await createOrderDialog.getByLabel("业务员").selectOption({label:"E2E 异动业务员"});
       await page.getByLabel("服务类型").fill("组织快照验收");
       await page.getByLabel("营业额").fill("100");
       await page.getByRole("button",{name:"确认入账"}).click();
@@ -586,11 +734,12 @@ test("订单搜索与不可变事件链在浏览器和数据库中保持一致",
       await page.getByRole("button", { name: "订单业绩", exact:true }).click();
 
       await page.getByRole("button", { name: "录入新订单" }).click();
+      const createOrderDialog=page.getByRole("dialog",{name:"录入订单业绩"});
       await page.getByLabel("订单编号").fill("CHAIN-E2E-110");
       await page.getByLabel("客户名称").fill("事件链客户");
-      await page.getByLabel("客户单位").fill("事件链测试单位");
-      await page.getByLabel("业务区域").selectOption("EXT-TRADE");
-      await page.getByLabel("业务员").selectOption({label:"E2E 账本业务员"});
+      await page.getByLabel("客户单位",{exact:true}).fill("事件链测试单位");
+      await createOrderDialog.getByLabel("业务区域").selectOption("EXT-TRADE");
+      await createOrderDialog.getByLabel("业务员").selectOption({label:"E2E 账本业务员"});
       await page.getByLabel("服务类型").fill("浏览器验收");
       await page.getByLabel("营业额").fill("110");
       await page.getByRole("button", { name: "确认入账" }).click();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,11 @@ type User = { id: string; personId:string; username: string; displayName: string
 type AuthState = { status: "loading" } | { status: "guest" } | { status: "authenticated"; user: User };
 type OrderLifecycle = "draft" | "active" | "paused" | "zero" | "historical_review_required";
 type Order = { id: string; orderNo: string; customerName: string; customerUnit: string; salespersonName: string; serviceType: string | null; sourceReceivedOn: string; originalAmount: string; currentRevenue: string; countedAmount: string; lifecycleState: OrderLifecycle; postedAt: string; departmentName:string; groupName:string; leaderName:string|null; supervisorName:string|null };
+type OrderFilters = { search:string;month:string;status:string;salesperson:string;department:string;group:string;region:string;customerUnit:string };
+const emptyOrderFilters:OrderFilters={search:"",month:"",status:"",salesperson:"",department:"",group:"",region:"",customerUnit:""};
+const orderFilterUrlKeys:Record<keyof OrderFilters,string>={search:"orderSearch",month:"orderMonth",status:"orderStatus",salesperson:"orderSalesperson",department:"orderDepartment",group:"orderGroup",region:"orderRegion",customerUnit:"orderCustomerUnit"};
+function readOrderUrlState(){const params=new URLSearchParams(window.location.search);const filters={...emptyOrderFilters};for(const key of Object.keys(orderFilterUrlKeys) as Array<keyof OrderFilters>)filters[key]=params.get(orderFilterUrlKeys[key])??"";return{filters,cursor:params.get("orderCursor")};}
+function writeOrderUrlState(filters:OrderFilters,cursor:string|null,mode:"push"|"replace"="push"){const params=new URLSearchParams(window.location.search);params.set("page","orders");for(const key of Object.keys(orderFilterUrlKeys) as Array<keyof OrderFilters>){if(filters[key])params.set(orderFilterUrlKeys[key],filters[key]);else params.delete(orderFilterUrlKeys[key]);}if(cursor)params.set("orderCursor",cursor);else params.delete("orderCursor");window.history[mode==="push"?"pushState":"replaceState"]({},"",`${window.location.pathname}?${params.toString()}${window.location.hash}`);}
 type PerformanceEvent = { id:string; sequence:number; eventType:string; deltaAmount:string; resultingCurrentRevenue:string; resultingCountedAmount:string; resultingLifecycleState:OrderLifecycle|null; accountingMonth:string; occurredOn:string; occurredAt:string; reason:string|null; actorName:string|null; salespersonName:string; departmentName:string|null; groupName:string|null; leaderName:string|null; supervisorName:string|null };
 type AccountingPeriod={periodMonth:string;status:"open"|"closed";version:number;needsReclose:boolean;verifiedAt:string|null;verifiedBy:string|null;closedAt:string|null;closedBy:string|null};
 type AccountingCorrection={id:string;periodMonth:string;orderId:string;orderNo:string;eventType:string;occurredOn:string;reason:string;status:"pending"|"approved"|"rejected"|"consumed"|"revoked";requestedBy:string;reviewedBy:string|null;reviewNote:string|null;expiresAt:string|null};
@@ -154,9 +159,16 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
     user.capabilities.viewApprovals ? {id:"approvals" as const,Icon:FileClock,label:"审批中心"} : null,
     user.capabilities.manageAccounts ? {id:"accounts" as const,Icon:UsersRound,label:"账号管理"} : null,
   ].filter((page):page is NonNullable<typeof page>=>page!==null);
-  const [active, setActive] = useState<PageId>(user.capabilities.manageAccounts ? "accounts" : pages[0]?.id??"overview");
+  const defaultPage:PageId=user.capabilities.manageAccounts?"accounts":pages[0]?.id??"overview";
+  const canOpenOrders=pages.some((page)=>page.id==="orders");
+  const requestedPage=new URLSearchParams(window.location.search).get("page");
+  const [active, setActive] = useState<PageId|"forbidden">(requestedPage==="orders"?(canOpenOrders?"orders":"forbidden"):defaultPage);
+  const navigate=useCallback((page:PageId)=>{const params=new URLSearchParams(window.location.search);if(page==="orders")params.set("page","orders");else params.delete("page");window.history.pushState({},"",`${window.location.pathname}${params.size?`?${params.toString()}`:""}${window.location.hash}`);setActive(page);},[]);
+  useEffect(()=>{const restore=()=>{const page=new URLSearchParams(window.location.search).get("page");setActive(page==="orders"?(canOpenOrders?"orders":"forbidden"):defaultPage);};window.addEventListener("popstate",restore);return()=>window.removeEventListener("popstate",restore);},[canOpenOrders,defaultPage]);
   async function logout() { await apiFetch("/api/auth/logout", { method: "POST" }); onLogout(); }
-  const content = active === "orders"
+  const content = active === "forbidden"
+    ? <main className="dashboard"><header><div><h1>无法访问订单业绩</h1><p>该页面需要业务查看权限</p></div></header><div className="permission-note"><ShieldCheck size={18}/>当前账号没有订单查看权限。</div></main>
+    : active === "orders"
     ? <OrdersPage user={user} />
     : active === "goals"
       ? <GoalsPage user={user} pendingOnly={false} />
@@ -166,8 +178,8 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
         ? <OrganizationPage user={user}/>
       : active === "accounts"
         ? <AccountsPage user={user}/>
-      : <Overview canEdit={user.capabilities.editPerformance} canExport={user.capabilities.exportPerformance} onEnterOrders={() => setActive("orders")} />;
-  return <div className="app-shell"><aside className="sidebar"><div className="sidebar-brand"><span>SF</span><strong>SampleFlow</strong></div><nav>{pages.map(({Icon,label,id}) => <button className={id === active ? "active" : ""} key={id} onClick={() => setActive(id)} aria-label={label} aria-current={id===active?"page":undefined}><Icon size={18}/><span>{label}</span></button>)}</nav><div className="sidebar-user"><div className="avatar">{user.displayName.slice(0,1)}</div><div><strong>{user.displayName}</strong><span>{user.roles.map((r) => roleNames[r] ?? r).join("、")}</span></div><button onClick={logout} aria-label="退出登录"><LogOut size={17}/></button></div></aside>{content}</div>;
+      : <Overview canEdit={user.capabilities.editPerformance} canExport={user.capabilities.exportPerformance} onEnterOrders={() => navigate("orders")} />;
+  return <div className="app-shell"><aside className="sidebar"><div className="sidebar-brand"><span>SF</span><strong>SampleFlow</strong></div><nav>{pages.map(({Icon,label,id}) => <button className={id === active ? "active" : ""} key={id} onClick={() => navigate(id)} aria-label={label} aria-current={id===active?"page":undefined}><Icon size={18}/><span>{label}</span></button>)}</nav><div className="sidebar-user"><div className="avatar">{user.displayName.slice(0,1)}</div><div><strong>{user.displayName}</strong><span>{user.roles.map((r) => roleNames[r] ?? r).join("、")}</span></div><button onClick={logout} aria-label="退出登录"><LogOut size={17}/></button></div></aside>{content}</div>;
 }
 
 function AccountsPage({user}:{user:User}){
@@ -293,57 +305,76 @@ function OrdersPage({ user }: { user: User }) {
   const [selected, setSelected] = useState<Order | null>(null);
   const [showCreate, setShowCreate] = useState(false);
   const [showImport, setShowImport] = useState(false);
-  const [message, setMessage] = useState("");
-  const initialSearch = new URLSearchParams(window.location.search).get("orderSearch") ?? "";
-  const [search, setSearch] = useState(initialSearch);
-  const [committedSearch, setCommittedSearch] = useState(initialSearch);
+  const initialUrlState=useRef(readOrderUrlState()).current;
+  const [draftFilters,setDraftFilters]=useState<OrderFilters>(initialUrlState.filters);
+  const [committedFilters,setCommittedFilters]=useState<OrderFilters>(initialUrlState.filters);
   const [isComposing, setIsComposing] = useState(false);
-  const [loading, setLoading] = useState(true);
+  const [loadState,setLoadState]=useState<"loading"|"ready"|"error"|"forbidden">("loading");
+  const [loadError,setLoadError]=useState("");
   const [refreshVersion, setRefreshVersion] = useState(0);
-  const [pageCursor, setPageCursor] = useState<string | null>(null);
+  const [pageCursor, setPageCursor] = useState<string | null>(initialUrlState.cursor);
   const [previousCursor, setPreviousCursor] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-  const commitSearch = useCallback((value:string, historyMode:"push"|"replace"="push") => {
-    const normalized=value.trim();
-    const params=new URLSearchParams(window.location.search);
-    if(normalized)params.set("orderSearch",normalized);else params.delete("orderSearch");
-    const next=`${window.location.pathname}${params.size?`?${params.toString()}`:""}${window.location.hash}`;
-    window.history[historyMode==="push"?"pushState":"replaceState"]({},"",next);
+  const commitFilters=useCallback((value:OrderFilters,historyMode:"push"|"replace"="push",updateDraft=true)=>{
+    const normalized:OrderFilters={
+      search:value.search.trim(),month:value.month.trim(),status:value.status.trim(),salesperson:value.salesperson.trim(),
+      department:value.department.trim(),group:value.group.trim(),region:value.region.trim(),customerUnit:value.customerUnit.trim(),
+    };
+    writeOrderUrlState(normalized,null,historyMode);
+    if(updateDraft)setDraftFilters(normalized);
     setPageCursor(null);
-    setCommittedSearch(normalized);
+    setCommittedFilters(normalized);
   },[]);
   useEffect(()=>{
-    const restore=()=>{const value=new URLSearchParams(window.location.search).get("orderSearch")??"";setSearch(value);setPageCursor(null);setCommittedSearch(value);};
+    const restore=()=>{const restored=readOrderUrlState();setDraftFilters(restored.filters);setCommittedFilters(restored.filters);setPageCursor(restored.cursor);};
     window.addEventListener("popstate",restore);return()=>window.removeEventListener("popstate",restore);
   },[]);
   useEffect(()=>{
-    if(isComposing||search.trim()===committedSearch)return;
-    const timer=window.setTimeout(()=>commitSearch(search),300);
+    if(isComposing||draftFilters.search.trim()===committedFilters.search)return;
+    const timer=window.setTimeout(()=>commitFilters({...committedFilters,search:draftFilters.search},"push",false),300);
     return()=>window.clearTimeout(timer);
-  },[search,isComposing,committedSearch,commitSearch]);
+  },[draftFilters.search,isComposing,committedFilters,commitFilters]);
+  const filterRequestKey=JSON.stringify(committedFilters);
+  const lastFilterRequestKey=useRef<string|null>(null);
   useEffect(() => {
-    const controller=new AbortController();setLoading(true);setMessage("");
-    const params=new URLSearchParams();if(committedSearch)params.set("search",committedSearch);if(pageCursor)params.set("cursor",pageCursor);
+    if(lastFilterRequestKey.current!==filterRequestKey){lastFilterRequestKey.current=filterRequestKey;setOrders([]);setPreviousCursor(null);setNextCursor(null);}
+    const controller=new AbortController();setLoadState("loading");setLoadError("");
+    const params=new URLSearchParams();for(const [key,value] of Object.entries(committedFilters))if(value)params.set(key,value);if(pageCursor)params.set("cursor",pageCursor);
     fetch(`/api/performance/orders?${params.toString()}`,{signal:controller.signal}).then(async(response)=>{
-      const data=await response.json() as {orders?:Order[];previousCursor?:string|null;nextCursor?:string|null;message?:string};
+      const data=await readResponseJson<{orders?:Order[];previousCursor?:string|null;nextCursor?:string|null;message?:string}>(response,"订单服务响应无效，请重试");
+      if(response.status===403){setOrders([]);setPreviousCursor(null);setNextCursor(null);setLoadState("forbidden");return;}
       if(!response.ok)throw new Error(data.message??"订单加载失败");
       setOrders(data.orders??[]);
       setPreviousCursor(data.previousCursor??null);setNextCursor(data.nextCursor??null);
-    }).catch((error)=>{if(error instanceof DOMException&&error.name==="AbortError")return;setMessage(error instanceof Error?error.message:"订单加载失败");})
-      .finally(()=>{if(!controller.signal.aborted)setLoading(false);});
+      setLoadState("ready");
+    }).catch((error)=>{if(error instanceof DOMException&&error.name==="AbortError")return;setLoadError(error instanceof Error?error.message:"订单加载失败");setLoadState("error");});
     return()=>controller.abort();
-  }, [committedSearch,pageCursor,refreshVersion]);
-  async function refresh() { setPageCursor(null);setRefreshVersion((value)=>value+1); }
-  function movePage(cursor:string|null){if(!cursor)return;if(cursor===pageCursor)setRefreshVersion((value)=>value+1);else setPageCursor(cursor);}
-  function clearSearch(){setSearch("");commitSearch("");window.requestAnimationFrame(()=>searchRef.current?.focus());}
+  }, [filterRequestKey,pageCursor,refreshVersion]);
+  const loading=loadState==="loading";
+  const hasFilters=Object.values(committedFilters).some(Boolean);
+  async function refresh() { writeOrderUrlState(committedFilters,null,"replace");setPageCursor(null);setRefreshVersion((value)=>value+1); }
+  function movePage(cursor:string|null){if(!cursor)return;if(cursor===pageCursor){setRefreshVersion((value)=>value+1);return;}writeOrderUrlState(committedFilters,cursor);setPageCursor(cursor);}
+  function clearSearch(){setDraftFilters((current)=>({...current,search:""}));commitFilters({...committedFilters,search:""},"push",false);window.requestAnimationFrame(()=>searchRef.current?.focus());}
+  function updateFilter(key:keyof OrderFilters,value:string){setDraftFilters((current)=>({...current,[key]:value}));}
+  const emptyMessage=loadState==="forbidden"?"无可显示订单。":loadState==="error"?"订单加载失败，可重试。":hasFilters?"没有符合当前组合条件的订单。":"暂无订单数据。";
   return <main className="dashboard orders-page"><header><div><h1>订单业绩</h1><p>按订单编号维护不可变业绩事件；已入账记录不能覆盖或删除</p></div>{canEdit ? <div className="header-actions"><button className="secondary-action" onClick={() => setShowImport(true)}><FileUp size={16}/>Excel 导入</button><button className="primary-action" onClick={() => setShowCreate(true)}><Plus size={16}/>录入新订单</button></div> : null}</header>
-    {message ? <p className="page-message" role="status">{message}</p> : null}
+    {loadState==="error"?<div className="query-feedback"><p className="page-message" role="alert">{loadError}</p><button type="button" onClick={()=>setRefreshVersion((value)=>value+1)}>重试查询</button></div>:null}
+    {loadState==="forbidden"?<div className="permission-note"><ShieldCheck size={18}/>当前账号没有订单查看权限。</div>:null}
     {!canEdit ? <div className="permission-note"><ShieldCheck size={18}/>当前角色仅可查看。只有销售助理及销售助理组长可以录入或调整业绩。</div> : null}
     <LedgerGovernancePanel user={user} orders={orders} onChanged={refresh}/>
     <section className="orders-card" aria-labelledby="orders-table-title"><div className="orders-toolbar"><div><h2 id="orders-table-title">订单台账</h2><span role="status">{loading?"正在查询…":`本页 ${orders.length} 笔订单`}</span></div><button className="icon-action" onClick={() => refresh()} aria-label="刷新订单"><RefreshCw size={17}/></button></div>
-      <form className="order-search" role="search" noValidate onSubmit={(event)=>{event.preventDefault();if(!isComposing)commitSearch(search);}}><label htmlFor="order-search-input">定位订单</label><div><Search size={17} aria-hidden="true"/><input ref={searchRef} id="order-search-input" type="search" value={search} placeholder="输入订单编号、客户名称、客户单位或业务员" onChange={(event)=>setSearch(event.target.value)} onCompositionStart={()=>setIsComposing(true)} onCompositionEnd={(event)=>{setIsComposing(false);setSearch(event.currentTarget.value);}}/>{search?<button type="button" onClick={clearSearch} aria-label="清除订单搜索"><X size={16}/></button>:null}</div><button type="submit">搜索</button></form>
-      <div className="orders-table-wrap"><table><thead><tr><th scope="col">订单编号</th><th scope="col">客户</th><th scope="col">业务员</th><th scope="col">当前营业额</th><th scope="col">计入业绩</th><th scope="col">状态</th><th scope="col">操作</th></tr></thead><tbody>{!loading&&orders.length === 0 ? <tr><td colSpan={7} className="empty-cell">{committedSearch?`没有找到与“${committedSearch}”匹配的订单。`:"暂无订单，请录入第一笔业绩。"}</td></tr> : orders.map((order) => <tr key={order.id}><td>{order.orderNo}</td><td>{order.customerName}</td><td>{order.salespersonName}</td><td>{formatMoney(order.currentRevenue)}</td><td>{formatMoney(order.countedAmount)}</td><td><Status state={order.lifecycleState}/></td><td><button className="table-action" onClick={() => setSelected(order)}>查看 / 调整</button></td></tr>)}</tbody></table></div>
+      <form className="order-search" role="search" noValidate onSubmit={(event)=>{event.preventDefault();if(!isComposing)commitFilters({...committedFilters,search:draftFilters.search},"push",false);}}><label htmlFor="order-search-input">定位订单</label><div><Search size={17} aria-hidden="true"/><input ref={searchRef} id="order-search-input" type="search" value={draftFilters.search} maxLength={100} placeholder="输入订单编号、客户名称、客户单位或业务员" onChange={(event)=>updateFilter("search",event.target.value)} onCompositionStart={()=>setIsComposing(true)} onCompositionEnd={(event)=>{setIsComposing(false);updateFilter("search",event.currentTarget.value);}}/>{draftFilters.search?<button type="button" onClick={clearSearch} aria-label="清除订单搜索"><X size={16}/></button>:null}</div><button type="submit">搜索</button></form>
+      <form className="order-filters" noValidate onSubmit={(event)=>{event.preventDefault();commitFilters(draftFilters);}}><div className="order-filter-grid">
+        <label className="field"><span>订单月份</span><input type="month" value={draftFilters.month} onChange={(event)=>updateFilter("month",event.target.value)}/></label>
+        <label className="field"><span>订单状态</span><select value={draftFilters.status} onChange={(event)=>updateFilter("status",event.target.value)}><option value="">全部状态</option><option value="active">正向计入</option><option value="paused">已暂停</option><option value="zero">零金额</option><option value="historical_review_required">待历史核对</option><option value="draft">草稿</option></select></label>
+        <label className="field"><span>业务员筛选</span><input value={draftFilters.salesperson} maxLength={300} onChange={(event)=>updateFilter("salesperson",event.target.value)}/></label>
+        <label className="field"><span>部门筛选</span><input value={draftFilters.department} maxLength={300} onChange={(event)=>updateFilter("department",event.target.value)}/></label>
+        <label className="field"><span>小组筛选</span><input value={draftFilters.group} maxLength={300} onChange={(event)=>updateFilter("group",event.target.value)}/></label>
+        <label className="field"><span>标准业务区域筛选</span><select value={draftFilters.region} onChange={(event)=>updateFilter("region",event.target.value)}><option value="">全部区域</option>{standardBusinessRegions.map(([code,name])=><option key={code} value={code}>{name}</option>)}</select></label>
+        <label className="field"><span>客户单位筛选</span><input value={draftFilters.customerUnit} maxLength={300} onChange={(event)=>updateFilter("customerUnit",event.target.value)}/></label>
+      </div><div className="order-filter-actions"><button type="button" onClick={()=>commitFilters({...emptyOrderFilters})}>清除筛选</button><button type="submit">应用筛选</button></div></form>
+      <div className="orders-table-wrap"><table><thead><tr><th scope="col">订单编号</th><th scope="col">客户</th><th scope="col">业务员</th><th scope="col">当前营业额</th><th scope="col">计入业绩</th><th scope="col">状态</th><th scope="col">操作</th></tr></thead><tbody>{!loading&&orders.length === 0 ? <tr><td colSpan={7} className="empty-cell">{emptyMessage}</td></tr> : orders.map((order) => <tr key={order.id}><td>{order.orderNo}</td><td>{order.customerName}</td><td>{order.salespersonName}</td><td>{formatMoney(order.currentRevenue)}</td><td>{formatMoney(order.countedAmount)}</td><td><Status state={order.lifecycleState}/></td><td><button className="table-action" onClick={() => setSelected(order)}>查看 / 调整</button></td></tr>)}</tbody></table></div>
       <nav className="table-pagination" aria-label="订单分页"><button type="button" disabled={loading||!previousCursor} onClick={()=>movePage(previousCursor)}>上一页</button><button type="button" disabled={loading||!nextCursor} onClick={()=>movePage(nextCursor)}>下一页</button></nav>
     </section>
     {showCreate ? <CreateOrder onClose={() => setShowCreate(false)} onSaved={async () => { setShowCreate(false); await refresh(); }} /> : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -363,6 +363,14 @@ th { color: #68778a; background: #fafbfc; font-weight: 600; }
 .order-search input::-webkit-search-cancel-button { appearance: none; }
 .order-search > div > button { position: absolute; top: 4px; right: 4px; width: 32px; height: 32px; margin: 0; padding: 0; border: 0; color: #64758a; background: transparent; display: grid; place-items: center; }
 .order-search > button { width: auto; height: 40px; margin: 0; padding: 0 17px; border: 1px solid var(--blue); color: #fff; background: var(--blue); }
+.order-filters { padding: 16px 20px; border-top: 1px solid var(--line); background: #fafbfc; }
+.order-filter-grid { display: grid; grid-template-columns: repeat(4, minmax(140px, 1fr)); gap: 12px; }
+.order-filter-grid .field { margin: 0; }
+.order-filter-actions { margin-top: 14px; display: flex; justify-content: flex-end; gap: 8px; }
+.order-filter-actions button, .query-feedback button { width: auto; height: 36px; margin: 0; padding: 0 14px; }
+.order-filter-actions button:last-child { border-color: var(--blue); color: #fff; background: var(--blue); }
+.query-feedback { display: flex; align-items: center; gap: 10px; }
+.query-feedback .page-message { flex: 1; }
 .table-pagination { padding: 14px 20px; border-top: 1px solid var(--line); display: flex; justify-content: flex-end; gap: 8px; }
 .table-pagination button { width: auto; height: 36px; margin: 0; padding: 0 14px; border: 1px solid var(--line); border-radius: 6px; color: #39495d; background: #fff; }
 .table-pagination button:disabled { color: #9aa6b5; background: #f4f5f7; cursor: not-allowed; }


### PR DESCRIPTION
Closes #43

- 增加月份、状态、业务员、部门、小组、标准业务区域、客户单位组合筛选
- 用 History API 保存筛选和游标，支持刷新、前进后退及详情返回恢复
- 服务端始终叠加权限范围，并用筛选摘要绑定分页游标
- 区分空数据、无匹配、加载失败和无权限

验证：npm.cmd run verify（API 132/132，Web 17/17，类型、构建、0 漏洞、Compose 配置通过）
复审：Spec 与 Standards P1/P2 cleared