### PR TITLE
[P1][TB-11] 地区与客户单位汇总对账

### DIFF
--- a/apps/api/src/authorization.integration.test.ts
+++ b/apps/api/src/authorization.integration.test.ts
@@ -8,6 +8,7 @@ import { withTestApi } from "./test-support/test-api.js";
 import { withMigratedTestDatabase } from "./test-support/test-database.js";
 import { resolvePerformanceAccess } from "./modules/authorization.js";
 import { ORGANIZATION_ACHIEVEMENT_SQL } from "./modules/performance.js";
+import { businessDate } from "./domain/business-time.js";
 
 const { Client, Pool } = pg;
 const TEST_ORIGIN = "http://127.0.0.1:4174";
@@ -1542,7 +1543,8 @@ test("订单导出复用组合筛选、权限范围与安全审计", async () =>
         return originalQuery(...args as [string, unknown[]]);
       }) as typeof client.query;
     });
-    const app = await buildApp({ database: pool, logger: false, clock: () => new Date("2026-08-31T16:30:00Z") });
+    const exportNow = new Date();
+    const app = await buildApp({ database: pool, logger: false, clock: () => exportNow });
     try {
       const leaderCookie = await loginCookie(app, "scope_leader");
       const filters = new URLSearchParams({
@@ -1561,7 +1563,7 @@ test("订单导出复用组合筛选、权限范围与安全审计", async () =>
       assert.ok(exportReadCount <= 2, `排除会话认证后，订单导出权限与数据读取应不超过 2 次，实际 ${exportReadCount} 次`);
       const smallReadCount = exportReadCount;
       assert.match(String(response.headers["content-type"]), /^text\/csv; charset=utf-8/);
-      assert.match(String(response.headers["content-disposition"]), /sampleflow-orders-2026-09-01\.csv/);
+      assert.match(String(response.headers["content-disposition"]), new RegExp(`sampleflow-orders-${businessDate(exportNow)}\\.csv`));
       assert.equal(response.body.charCodeAt(0), 0xfeff);
       const lines = response.body.split("\r\n");
       assert.equal(lines.length, 52);

--- a/apps/api/src/modules/performance.ts
+++ b/apps/api/src/modules/performance.ts
@@ -150,6 +150,15 @@ type AchievementRow = Readonly<{
   event_count: string;
 }>;
 
+type PerformanceAnalysisRow = Readonly<{
+  kind: "ledger" | "mapped" | "pending" | "province" | "foreign_trade" | "customer";
+  region_code: string | null;
+  customer_unit: string | null;
+  event_count: string;
+  total_amount: string;
+  reconciled: boolean;
+}>;
+
 function timeProgressRate(periodMonth: string, today: string): string | null {
   const currentMonth = today.slice(0, 7);
   if (periodMonth > currentMonth) return null;
@@ -827,6 +836,102 @@ export async function registerPerformance(app: FastifyInstance, db: Database, cl
     const result = await loadFormalReport(db, request.currentUser, params.data.goalId, businessDate(clock()));
     if (!result.ok) return reply.code(result.statusCode).send(result.body);
     return result.report;
+  });
+
+  app.get("/api/performance/analysis", async (request, reply) => {
+    if (!request.currentUser) return reply.code(401).send({ message: "尚未登录" });
+    const parsed = dashboardQuerySchema.safeParse(request.query);
+    if (!parsed.success) return reply.code(400).send({ code: "MONTH_INVALID", message: "月份格式无效" });
+    const month = parsed.data.month ?? businessDate(clock()).slice(0, 7);
+    const client = await db.connect();
+    try {
+      await client.query("begin transaction isolation level repeatable read read only");
+      const access = await resolvePerformanceAccess(client, request.currentUser);
+      if (!canReadPerformance(access)) {
+        await client.query("rollback");
+        return reply.code(403).send({ message: "当前角色没有业务查看权限" });
+      }
+      const result = await client.query<PerformanceAnalysisRow>(
+        `with scoped_analysis as materialized (
+           select e.delta_amount,dimensions.event_id as dimensions_event_id,
+                  dimensions.business_region_code,dimensions.customer_unit
+           from performance_events e
+           left join performance_event_analysis_dimensions dimensions on dimensions.event_id=e.id
+           where e.accounting_month=$1::date and ${performanceScopeSql("e", 2)}
+         ), summary as (
+           select count(*)::bigint as ledger_count,
+                  coalesce(sum(delta_amount),0.00) as ledger_amount,
+                  count(*) filter(where dimensions_event_id is not null)::bigint as mapped_count,
+                  coalesce(sum(delta_amount) filter(where dimensions_event_id is not null),0.00) as mapped_amount,
+                  count(*) filter(where dimensions_event_id is null)::bigint as pending_count,
+                  coalesce(sum(delta_amount) filter(where dimensions_event_id is null),0.00) as pending_amount
+           from scoped_analysis
+         ), aggregates as (
+           select 'ledger'::text as kind,null::text as region_code,null::text as customer_unit,
+                  ledger_count as event_count,ledger_amount as total_amount from summary
+           union all
+           select 'mapped',null,null,mapped_count,mapped_amount from summary
+           union all
+           select 'pending',null,null,pending_count,pending_amount from summary
+           union all
+           select 'province',business_region_code,null,count(*)::bigint,sum(delta_amount)
+           from scoped_analysis where business_region_code like 'CN-%' group by business_region_code
+           union all
+           select 'foreign_trade','EXT-TRADE',null,count(*)::bigint,coalesce(sum(delta_amount),0.00)
+           from scoped_analysis where business_region_code='EXT-TRADE'
+           union all
+           select 'customer',business_region_code,customer_unit,count(*)::bigint,sum(delta_amount)
+           from scoped_analysis where dimensions_event_id is not null group by business_region_code,customer_unit
+         )
+         select aggregates.kind,aggregates.region_code,aggregates.customer_unit,
+                aggregates.event_count::text,aggregates.total_amount::text,
+                (summary.ledger_count=summary.mapped_count+summary.pending_count
+                 and summary.ledger_amount=summary.mapped_amount+summary.pending_amount) as reconciled
+         from aggregates cross join summary
+         order by case aggregates.kind when 'ledger' then 1 when 'mapped' then 2 when 'pending' then 3
+                  when 'province' then 4 when 'foreign_trade' then 5 else 6 end,
+                  aggregates.total_amount desc,aggregates.region_code,aggregates.customer_unit`,
+        [`${month}-01`, ...performanceScopeValues(access)],
+      );
+      await client.query("commit");
+      const summary = (kind: PerformanceAnalysisRow["kind"]) => {
+        const row = result.rows.find((item) => item.kind === kind)!;
+        return { eventCount: Number(row.event_count), totalAmount: row.total_amount };
+      };
+      const regions = result.rows.filter((row) => row.kind === "province");
+      const foreignTrade = result.rows.find((row) => row.kind === "foreign_trade")!;
+      return {
+        month,
+        ledger: summary("ledger"),
+        mapped: summary("mapped"),
+        pending: summary("pending"),
+        reconciled: result.rows[0]!.reconciled,
+        provinces: regions.map((row) => ({
+          regionCode: row.region_code!,
+          regionName: standardBusinessRegionName(row.region_code!) ?? row.region_code!,
+          eventCount: Number(row.event_count),
+          totalAmount: row.total_amount,
+        })),
+        foreignTrade: {
+          regionCode: "EXT-TRADE",
+          regionName: standardBusinessRegionName("EXT-TRADE")!,
+          eventCount: Number(foreignTrade.event_count),
+          totalAmount: foreignTrade.total_amount,
+        },
+        customers: result.rows.filter((row) => row.kind === "customer").map((row) => ({
+          regionCode: row.region_code!,
+          regionName: standardBusinessRegionName(row.region_code!) ?? row.region_code!,
+          customerUnit: row.customer_unit!,
+          eventCount: Number(row.event_count),
+          totalAmount: row.total_amount,
+        })),
+      };
+    } catch (error) {
+      await client.query("rollback");
+      throw error;
+    } finally {
+      client.release();
+    }
   });
 
   app.get("/api/performance/dashboard", async (request, reply) => {

--- a/apps/api/src/performance-analysis.integration.test.ts
+++ b/apps/api/src/performance-analysis.integration.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import pg from "pg";
+import { buildApp } from "./app.js";
+import { seedTestUser } from "./test-support/fixtures.js";
+import { withMigratedTestDatabase } from "./test-support/test-database.js";
+
+const { Client, Pool } = pg;
+const TEST_ORIGIN = "http://127.0.0.1:4174";
+type CapturedQuery = { statement: string; values: unknown[] };
+
+function requireCapturedQuery(value: CapturedQuery | null): CapturedQuery {
+  if (!value) throw new Error("未捕获地区与客户分析 SQL");
+  return value;
+}
+
+function assertNoPerRowAnalysisScan(plan: Record<string, unknown>, baseline: string): void {
+  const repeatedNodes: Array<Record<string, unknown>> = [];
+  const visit = (node: Record<string, unknown>) => {
+    const relation = String(node["Relation Name"] ?? "");
+    const loops = Number(node["Actual Loops"] ?? 0);
+    const boundedDimensionLookup = relation === "performance_event_analysis_dimensions"
+      && node["Node Type"] === "Index Scan"
+      && node["Index Name"] === "performance_event_analysis_dimensions_pkey"
+      && Number(node["Actual Rows"] ?? 0) <= 1;
+    if (loops > 1 && (node["Parent Relationship"] === "SubPlan" || relation === "performance_events" || (relation === "performance_event_analysis_dimensions" && !boundedDimensionLookup))) repeatedNodes.push(node);
+    for (const child of (node.Plans as Array<Record<string, unknown>> | undefined) ?? []) visit(child);
+  };
+  visit(plan);
+  assert.deepEqual(repeatedNodes, [], `${baseline}分析查询不得逐输出行重复扫描事件或维度`);
+}
+
+async function loginCookie(app: Awaited<ReturnType<typeof buildApp>>, username: string): Promise<string> {
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    headers: { origin: TEST_ORIGIN },
+    payload: { username, password: "Role@123" },
+  });
+  assert.equal(response.statusCode, 200, response.body);
+  const setCookies = Array.isArray(response.headers["set-cookie"])
+    ? response.headers["set-cookie"].map(String)
+    : [String(response.headers["set-cookie"])];
+  return setCookies.map((value) => value.split(";", 1)[0]).join("; ");
+}
+
+test("地区与客户分析按事件快照对账且查询次数不随规模增长", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    const leaderUserId = await seedTestUser(database.url, { username: "analysis_leader", displayName: "分析组长", password: "Role@123", roleCode: "sales_leader", roleName: "业务员组长" });
+    const aliceUserId = await seedTestUser(database.url, { username: "analysis_alice", displayName: "分析业务员", password: "Role@123", roleCode: "salesperson", roleName: "业务员" });
+    const bobUserId = await seedTestUser(database.url, { username: "analysis_bob", displayName: "范围外业务员", password: "Role@123", roleCode: "salesperson", roleName: "业务员" });
+    await seedTestUser(database.url, { username: "analysis_admin", displayName: "纯系统管理员", password: "Role@123", roleCode: "system_admin", roleName: "系统管理员" });
+
+    const setup = new Client({ connectionString: database.url });
+    await setup.connect();
+    try {
+      const people = await setup.query<{ user_id: string; person_id: string }>(
+        "select user_id::text,p.id::text as person_id from people p where user_id=any($1::bigint[])",
+        [[leaderUserId, aliceUserId, bobUserId]],
+      );
+      const personByUser = Object.fromEntries(people.rows.map((row) => [row.user_id, row.person_id]));
+      const leaderPersonId = personByUser[leaderUserId]!;
+      const alicePersonId = personByUser[aliceUserId]!;
+      const bobPersonId = personByUser[bobUserId]!;
+      const departmentA = await setup.query<{ id: string }>("insert into org_units(name,unit_type) values('分析甲部','department') returning id::text");
+      const departmentB = await setup.query<{ id: string }>("insert into org_units(name,unit_type) values('分析乙部','department') returning id::text");
+      const groupA = await setup.query<{ id: string }>("insert into org_units(name,unit_type,parent_id) values('分析甲组','group',$1) returning id::text", [departmentA.rows[0]!.id]);
+      const groupB = await setup.query<{ id: string }>("insert into org_units(name,unit_type,parent_id) values('分析乙组','group',$1) returning id::text", [departmentB.rows[0]!.id]);
+      await setup.query(
+        `insert into org_responsibilities(person_id,org_unit_id,responsibility_type,effective_from)
+         values($1,$2,'leader','2026-01-01')`,
+        [leaderPersonId, groupA.rows[0]!.id],
+      );
+      const order = await setup.query<{ id: string }>(
+        `insert into performance_orders
+           (qingflow_order_no,customer_name,customer_unit,business_region_source_text,business_region_code,
+            salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+         values('ANALYSIS-CROSS','跨维度客户','订单当前单位','广东当前值','CN-GD',$1,'分析业务员','2026-08-01',155,155,155,'active',now())
+         returning id::text`,
+        [alicePersonId],
+      );
+      const outOfScopeOrder = await setup.query<{ id: string }>(
+        `insert into performance_orders
+           (qingflow_order_no,customer_name,customer_unit,business_region_source_text,business_region_code,
+            salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+         values('ANALYSIS-OUT','范围外客户','范围外单位','范围外地区','CN-BJ',$1,'范围外业务员','2026-08-01',999,999,999,'active',now())
+         returning id::text`,
+        [bobPersonId],
+      );
+
+      async function insertEvent(orderId: string, amount: number, month: string, salespersonPersonId: string, departmentId: string, departmentName: string, groupId: string, groupName: string) {
+        return (await setup.query<{ id: string }>(
+          `insert into performance_events
+             (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,
+              salesperson_person_id,salesperson_name,department_unit_id,department_name,group_unit_id,group_name,leader_person_id,leader_name)
+           values($1,'legacy_adjustment',$2,155,155,$3::date,$3::date,'分析回归',$4,$5,$6,$7,$8,$9,$10,'分析组长')
+           returning id::text`,
+          [orderId, amount, month, salespersonPersonId, salespersonPersonId === bobPersonId ? "范围外业务员" : "分析业务员", departmentId, departmentName, groupId, groupName, leaderPersonId],
+        )).rows[0]!.id;
+      }
+
+      const eventIds = [
+        await insertEvent(order.rows[0]!.id, 100, "2026-08-01", alicePersonId, departmentA.rows[0]!.id, "分析甲部", groupA.rows[0]!.id, "分析甲组"),
+        await insertEvent(order.rows[0]!.id, -25, "2026-08-01", alicePersonId, departmentA.rows[0]!.id, "分析甲部", groupA.rows[0]!.id, "分析甲组"),
+        await insertEvent(order.rows[0]!.id, 50, "2026-08-01", alicePersonId, departmentA.rows[0]!.id, "分析甲部", groupA.rows[0]!.id, "分析甲组"),
+        await insertEvent(order.rows[0]!.id, 0, "2026-08-01", alicePersonId, departmentA.rows[0]!.id, "分析甲部", groupA.rows[0]!.id, "分析甲组"),
+        await insertEvent(order.rows[0]!.id, 30, "2026-08-01", alicePersonId, departmentA.rows[0]!.id, "分析甲部", groupA.rows[0]!.id, "分析甲组"),
+        await insertEvent(order.rows[0]!.id, 7, "2026-09-01", alicePersonId, departmentA.rows[0]!.id, "分析甲部", groupA.rows[0]!.id, "分析甲组"),
+      ];
+      const outOfScopeEventId = await insertEvent(outOfScopeOrder.rows[0]!.id, 999, "2026-08-01", bobPersonId, departmentB.rows[0]!.id, "分析乙部", groupB.rows[0]!.id, "分析乙组");
+
+      await setup.query("set session_replication_role=replica");
+      await setup.query("delete from performance_event_analysis_dimensions where event_id=any($1::bigint[])", [[...eventIds, outOfScopeEventId]]);
+      await setup.query(
+        `insert into performance_event_analysis_dimensions(event_id,business_region_code,business_region_source_text,customer_unit)
+         values($1,'CN-JS','江苏来源','客户单位甲'),($2,'EXT-TRADE','外贸','客户单位乙'),
+               ($3,'CN-ZJ','浙江来源','客户单位甲'),($4,'CN-JS','江苏来源','客户单位甲'),
+               ($5,'CN-JS','江苏来源','客户单位甲'),($6,'CN-BJ','北京来源','范围外单位')`,
+        [eventIds[0], eventIds[1], eventIds[2], eventIds[3], eventIds[5], outOfScopeEventId],
+      );
+      await setup.query("set session_replication_role=origin");
+      await setup.query("update performance_orders set customer_unit='已变更当前单位',business_region_code='CN-GD',business_region_source_text='广东当前值' where id=$1", [order.rows[0]!.id]);
+
+      const runtimeUrl = new URL(database.url);
+      runtimeUrl.searchParams.set("application_name", "sampleflow-api-runtime");
+      const pool = new Pool({ connectionString: runtimeUrl.toString() });
+      let analysisReadCount = 0;
+      let analysisQuery: CapturedQuery | null = null;
+      const patched = new WeakSet<pg.PoolClient>();
+      pool.on("acquire", (client) => {
+        if (patched.has(client)) return;
+        patched.add(client);
+        const originalQuery = client.query.bind(client);
+        client.query = ((...args: unknown[]) => {
+          const statement = typeof args[0] === "string" ? args[0] : String((args[0] as { text?: string })?.text ?? "");
+          if (/^\s*(select|with)\b/i.test(statement) && !/\bfrom sessions\b/i.test(statement)) analysisReadCount += 1;
+          if (/with scoped_analysis as materialized/i.test(statement)) {
+            const values = typeof args[0] === "string" ? args[1] : (args[0] as { values?: unknown[] }).values;
+            analysisQuery = { statement, values: Array.isArray(values) ? [...values] : [] };
+          }
+          return originalQuery(...args as [string, unknown[]]);
+        }) as typeof client.query;
+      });
+      const app = await buildApp({ database: pool, logger: false });
+      try {
+        const leaderCookie = await loginCookie(app, "analysis_leader");
+        analysisReadCount = 0;
+        const response = await app.inject({ method: "GET", url: "/api/performance/analysis?month=2026-08", headers: { cookie: leaderCookie } });
+        assert.equal(response.statusCode, 200, response.body);
+        const body = response.json();
+        assert.deepEqual(body.ledger, { eventCount: 5, totalAmount: "155.00" });
+        assert.deepEqual(body.mapped, { eventCount: 4, totalAmount: "125.00" });
+        assert.deepEqual(body.pending, { eventCount: 1, totalAmount: "30.00" });
+        assert.equal(body.reconciled, true);
+        assert.deepEqual(body.provinces, [
+          { regionCode: "CN-JS", regionName: "江苏省", eventCount: 2, totalAmount: "100.00" },
+          { regionCode: "CN-ZJ", regionName: "浙江省", eventCount: 1, totalAmount: "50.00" },
+        ]);
+        assert.deepEqual(body.foreignTrade, { regionCode: "EXT-TRADE", regionName: "外贸", eventCount: 1, totalAmount: "-25.00" });
+        assert.ok(body.provinces.every((item: { regionCode: string }) => item.regionCode !== "EXT-TRADE"));
+        assert.deepEqual(body.customers, [
+          { regionCode: "CN-JS", regionName: "江苏省", customerUnit: "客户单位甲", eventCount: 2, totalAmount: "100.00" },
+          { regionCode: "CN-ZJ", regionName: "浙江省", customerUnit: "客户单位甲", eventCount: 1, totalAmount: "50.00" },
+          { regionCode: "EXT-TRADE", regionName: "外贸", customerUnit: "客户单位乙", eventCount: 1, totalAmount: "-25.00" },
+        ]);
+        assert.ok(analysisReadCount <= 4, `分析请求数据库读取应不超过 4 次，实际 ${analysisReadCount} 次`);
+        const smallReadCount = analysisReadCount;
+        const capturedAnalysisQuery = requireCapturedQuery(analysisQuery);
+        assert.doesNotMatch(capturedAnalysisQuery.statement, /performance_orders/i);
+        const smallExplain = await setup.query<{ "QUERY PLAN": Array<{ Plan: Record<string, unknown> }> }>(
+          `explain (analyze,format json) ${capturedAnalysisQuery.statement}`,
+          capturedAnalysisQuery.values,
+        );
+        assertNoPerRowAnalysisScan(smallExplain.rows[0]!["QUERY PLAN"][0]!.Plan, "小基线");
+
+        const september = await app.inject({ method: "GET", url: "/api/performance/analysis?month=2026-09", headers: { cookie: leaderCookie } });
+        assert.equal(september.statusCode, 200, september.body);
+        assert.deepEqual(september.json().ledger, { eventCount: 1, totalAmount: "7.00" });
+        assert.deepEqual(september.json().pending, { eventCount: 0, totalAmount: "0.00" });
+
+        await setup.query("set session_replication_role=replica");
+        await setup.query(
+          `with new_orders as (
+             insert into performance_orders
+               (qingflow_order_no,customer_name,customer_unit,business_region_source_text,business_region_code,
+                salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+             select 'ANALYSIS-SCALE-'||lpad(series::text,4,'0'),'规模客户','客户单位甲','江苏来源','CN-JS',
+                    $1,'分析业务员','2026-08-01',1,1,1,'active',now()
+             from generate_series(1,2849) series returning id,qingflow_order_no
+           ), numbered_orders as (
+             select id,row_number() over(order by qingflow_order_no) as number from new_orders
+           ), new_events as (
+             insert into performance_events
+               (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,
+                salesperson_person_id,salesperson_name,department_unit_id,department_name,group_unit_id,group_name,leader_person_id,leader_name,order_sequence)
+             select orders.id,case when series<=2849 then 'initial' else 'legacy_adjustment' end,1,
+                    1+((series-1)/2849)::int,1+((series-1)/2849)::int,
+                    '2026-08-01','2026-08-01','规模回归',$1,'分析业务员',$2,'分析甲部',$3,'分析甲组',$4,'分析组长',
+                    1+((series-1)/2849)::int
+             from generate_series(1,4696) series
+             join numbered_orders orders on orders.number=((series-1)%2849)+1
+             returning id
+           )
+           insert into performance_event_analysis_dimensions(event_id,business_region_code,business_region_source_text,customer_unit)
+           select id,'CN-JS','江苏来源','客户单位甲' from new_events`,
+          [alicePersonId, departmentA.rows[0]!.id, groupA.rows[0]!.id, leaderPersonId],
+        );
+        await setup.query("set session_replication_role=origin");
+        const scale = await setup.query<{ orders: string; events: string }>(
+          `select count(distinct order_id)::text as orders,count(*)::text as events
+           from performance_events where accounting_month='2026-08-01' and group_unit_id=$1`,
+          [groupA.rows[0]!.id],
+        );
+        assert.deepEqual(scale.rows[0], { orders: "2850", events: "4701" });
+        await setup.query("analyze performance_events");
+        await setup.query("analyze performance_event_analysis_dimensions");
+        analysisReadCount = 0;
+        const scaled = await app.inject({ method: "GET", url: "/api/performance/analysis?month=2026-08", headers: { cookie: leaderCookie } });
+        assert.equal(scaled.statusCode, 200, scaled.body);
+        assert.ok(analysisReadCount <= 4, `规模数据分析读取应不超过 4 次，实际 ${analysisReadCount} 次`);
+        assert.ok(Math.abs(analysisReadCount - smallReadCount) <= 1, `规模增长前后读取次数差应不超过 1，实际 ${smallReadCount} -> ${analysisReadCount}`);
+
+        const largeExplain = await setup.query<{ "QUERY PLAN": Array<{ Plan: Record<string, unknown> }> }>(
+          `explain (analyze,format json) ${capturedAnalysisQuery.statement}`,
+          capturedAnalysisQuery.values,
+        );
+        assertNoPerRowAnalysisScan(largeExplain.rows[0]!["QUERY PLAN"][0]!.Plan, "2,850 订单／4,701 事件基线");
+
+        const adminCookie = await loginCookie(app, "analysis_admin");
+        const forbidden = await app.inject({ method: "GET", url: "/api/performance/analysis?month=2026-08", headers: { cookie: adminCookie } });
+        assert.equal(forbidden.statusCode, 403, forbidden.body);
+        const invalid = await app.inject({ method: "GET", url: "/api/performance/analysis?month=2026-13", headers: { cookie: leaderCookie } });
+        assert.equal(invalid.statusCode, 400, invalid.body);
+      } finally {
+        await app.close();
+        await pool.end();
+      }
+    } finally {
+      await setup.end();
+    }
+  });
+});

--- a/apps/web/e2e/analysis.spec.ts
+++ b/apps/web/e2e/analysis.spec.ts
@@ -1,0 +1,112 @@
+import pg from "pg";
+import { seedTestUser } from "../../api/src/test-support/fixtures.js";
+import { expect, test } from "./full-stack.js";
+
+const { Client } = pg;
+
+test.use({ locale: "zh-CN", timezoneId: "Asia/Shanghai", viewport: { width: 1280, height: 800 } });
+
+test("桌面总览显示事件快照地区、外贸、客户单位和待补齐对账", async ({ database, page }) => {
+  const userId = await seedTestUser(database.url, {
+    username: "e2e_analysis_assistant",
+    displayName: "E2E 分析助理",
+    password: "Analysis@123",
+    roleCode: "sales_assistant",
+    roleName: "销售助理",
+  });
+  const client = new Client({ connectionString: database.url });
+  await client.connect();
+  try {
+    const person = await client.query<{ id: string }>("select id::text from people where user_id=$1", [userId]);
+    const order = await client.query<{ id: string }>(
+      `insert into performance_orders
+         (qingflow_order_no,customer_name,customer_unit,business_region_source_text,business_region_code,
+          salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+       values('E2E-ANALYSIS','E2E 分析客户','订单当前单位','广东当前值','CN-GD',$1,'E2E 分析助理',
+              '2026-08-01',155,155,155,'active',now()) returning id::text`,
+      [person.rows[0]!.id],
+    );
+    const events = await client.query<{ id: string }>(
+      `insert into performance_events
+         (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,
+          salesperson_person_id,salesperson_name,department_name,group_name)
+       values($1,'initial',100,100,100,'2026-08-01','2026-08-01','地区分析',$2,'E2E 分析助理','E2E 部','E2E 组'),
+             ($1,'legacy_adjustment',-25,75,75,'2026-08-01','2026-08-02','外贸分析',$2,'E2E 分析助理','E2E 部','E2E 组'),
+             ($1,'legacy_adjustment',50,125,125,'2026-08-01','2026-08-03','地区分析',$2,'E2E 分析助理','E2E 部','E2E 组'),
+             ($1,'legacy_adjustment',30,155,155,'2026-08-01','2026-08-04','待补齐分析',$2,'E2E 分析助理','E2E 部','E2E 组')
+       returning id::text`,
+      [order.rows[0]!.id, person.rows[0]!.id],
+    );
+    await client.query(
+      `with large_orders as (
+         insert into performance_orders
+           (qingflow_order_no,customer_name,customer_unit,business_region_source_text,business_region_code,
+            salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+         select 'E2E-ANALYSIS-LARGE-'||series,'E2E 大额分析客户','大额客户','江苏来源','CN-JS',
+                $1,'E2E 分析助理','2026-08-05',999999999999.99,999999999999.99,999999999999.99,'active',now()
+         from generate_series(1,101) series
+         returning id
+       )
+       insert into performance_events
+         (order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,
+          salesperson_person_id,salesperson_name,department_name,group_name)
+       select id,'initial',999999999999.99,999999999999.99,999999999999.99,'2026-08-01','2026-08-05','大额分币精度',
+              $1,'E2E 分析助理','E2E 部','E2E 组'
+       from large_orders`,
+      [person.rows[0]!.id],
+    );
+    await client.query("set session_replication_role=replica");
+    await client.query("delete from performance_event_analysis_dimensions where event_id=any($1::bigint[])", [events.rows.map((row) => row.id)]);
+    await client.query(
+      `insert into performance_event_analysis_dimensions(event_id,business_region_code,business_region_source_text,customer_unit)
+       values($1,'CN-JS','江苏来源','客户单位甲'),($2,'EXT-TRADE','外贸','客户单位乙'),($3,'CN-ZJ','浙江来源','客户单位甲')`,
+      [events.rows[0]!.id, events.rows[1]!.id, events.rows[2]!.id],
+    );
+    await client.query("set session_replication_role=origin");
+  } finally {
+    await client.end();
+  }
+
+  await page.goto("/");
+  await page.getByLabel("账号").fill("e2e_analysis_assistant");
+  await page.getByLabel("密码", { exact: true }).fill("Analysis@123");
+  await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+
+  const analysis = page.getByRole("region", { name: "地区与客户单位分析" });
+  await analysis.getByLabel("分析月份").fill("2026-08");
+  await expect(analysis.getByText("已映射金额 + 待补齐金额与授权范围总账完全对平。", { exact: true })).toBeVisible();
+  await expect(analysis.getByText("¥101,000,000,000,153.99", { exact: true })).toBeVisible();
+  await expect(analysis.getByText("¥101,000,000,000,123.99", { exact: true })).toBeVisible();
+  await expect(analysis.getByText("¥30.00", { exact: true })).toBeVisible();
+
+  const provinces = analysis.getByRole("table", { name: "省份汇总" });
+  await expect(provinces.getByRole("row", { name: /江苏省.*102.*¥101,000,000,000,098\.99/ })).toBeVisible();
+  await expect(provinces.getByRole("row", { name: /浙江省.*1.*¥50\.00/ })).toBeVisible();
+  await expect(provinces.getByText("外贸", { exact: true })).toHaveCount(0);
+  await expect(analysis.getByText("外贸（EXT-TRADE）", { exact: true })).toBeVisible();
+  await expect(analysis.getByText("1 条事件 · -¥25.00", { exact: true })).toBeVisible();
+
+  const customers = analysis.getByRole("table", { name: "客户单位汇总" });
+  await expect(customers.getByRole("row", { name: /江苏省.*客户单位甲.*1.*¥100\.00/ })).toBeVisible();
+  await expect(customers.getByRole("row", { name: /江苏省.*大额客户.*101.*¥100,999,999,999,998\.99/ })).toBeVisible();
+  await expect(customers.getByRole("row", { name: /外贸.*客户单位乙.*1.*-¥25\.00/ })).toBeVisible();
+
+  let releaseResponse!: () => void;
+  let markRequested!: () => void;
+  const heldResponse = new Promise<void>((resolve) => { releaseResponse = resolve; });
+  const requestStarted = new Promise<void>((resolve) => { markRequested = resolve; });
+  await page.route("**/api/performance/analysis?month=2026-09", async (route) => {
+    markRequested();
+    await heldResponse;
+    await route.continue();
+  });
+  await analysis.getByLabel("分析月份").fill("2026-09");
+  await requestStarted;
+  try {
+    await expect(analysis.getByRole("status")).toHaveText("正在读取地区与客户单位分析…");
+    await expect(analysis.getByText("¥101,000,000,000,153.99", { exact: true })).toHaveCount(0);
+  } finally {
+    releaseResponse();
+  }
+  await expect(analysis.locator(".metric").filter({ hasText: "授权范围总账" }).getByText("¥0.00", { exact: true })).toBeVisible();
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -29,6 +29,8 @@ type DepartmentAchievementDrilldown = DepartmentAchievement&{groups:Organization
 type SalesAchievement = PersonalAchievement&{departmentCount:number};
 type SalesAchievementDrilldown = SalesAchievement&{departments:DepartmentAchievementDrilldown[]};
 type DashboardData = { month: string; metrics: { total: string; eventCount: number; negativeTotal: string; pendingApprovals: number }; monthly: Array<{ month: string; total: string }>; groups: Array<{ id:string;name:string;total:string }>; recent: Array<{ orderNo: string; salespersonName: string; eventType: string; month: string; amount: string; groupName: string }>; personalAchievement:PersonalAchievement|null;groupAchievements:GroupAchievement[];departmentAchievements:DepartmentAchievement[];salesAchievement:SalesAchievement|null };
+type AnalysisAmount = { eventCount:number;totalAmount:string };
+type PerformanceAnalysis = { month:string;ledger:AnalysisAmount;mapped:AnalysisAmount;pending:AnalysisAmount;reconciled:boolean;provinces:Array<{regionCode:string;regionName:string;eventCount:number;totalAmount:string}>;foreignTrade:{regionCode:"EXT-TRADE";regionName:string;eventCount:number;totalAmount:string};customers:Array<{regionCode:string;regionName:string;customerUnit:string;eventCount:number;totalAmount:string}> };
 type GoalLevel="sales_manager"|"department"|"group"|"personal";
 type Goal = { id:string;periodMonth:string;level:GoalLevel;ownerUsername:string|null;ownerName:string;ownerPersonId:string;orgUnitId:string|null;orgUnitName:string|null;parentGoalId:string|null;versionId:string;versionNo:string;amount:string;effectiveAmount:string|null;status:string;signatureText:string|null;signedAt:string|null;changeReason:string;allocatedAmount:string;allocationDifference:string;allocationType:"unallocated"|"overallocated"|"balanced";allocationRatio:string|null };
 type GoalOption={personId:string;name:string;orgUnitId:string|null;orgUnitName:string|null};
@@ -294,9 +296,23 @@ function Overview({ canEdit, canExport, onEnterOrders }: { canEdit: boolean; can
         onClose={()=>{groupDetailsRequest.current+=1;setSelectedGroup(null);}}
       >{groupDetailsError?<p className="form-error group-drilldown" role="alert">{groupDetailsError}</p>:groupDetails?<div className="group-drilldown"><AchievementMembers members={groupDetails.members}/></div>:<p className="group-drilldown">正在读取小组业绩构成…</p>}</Modal>:null}
       <section className="metric-band"><Metric label="账本净额" value={data ? formatMoney(data.metrics.total) : "—"} note={`${data?.metrics.eventCount ?? 0} 条授权范围事件`}/><Metric label="正式报表" value="从生效目标进入" note="未生效不计算达成率"/><Metric label="待处理审批" value={String(data?.metrics.pendingApprovals ?? 0)} note="目标确认与变更" warning/><Metric label="负向调整" value={data ? formatMoney(data.metrics.negativeTotal) : "—"} note="暂停与金额变更" negative/></section>
+      <AnalysisPanel/>
       <section className="dashboard-grid"><article className="trend-panel"><PanelTitle title="月度业绩趋势" note={`${data?.month.slice(0,4)??"当前"} 年授权范围业绩净额`}/><TrendChart year={data?.month.slice(0,4)??""} monthly={data?.monthly??[]}/></article><article className="ranking-panel"><PanelTitle title="小组业绩" note="按事件发生时组织归属"/>{data?.groups.map((group,i) => <div className="rank-row" key={group.id}><span>{i+1}</span><div><strong>{group.name}</strong><span><i style={{width:`${Math.max(0, Number(group.total)) / maxGroup * 100}%`}}/></span></div><b>{(Number(group.total)/10000).toFixed(1)}万</b></div>)}</article></section>
       <section className="events-panel"><div className="panel-title"><div><h2>最近业绩事件</h2><p>入账后不可覆盖或删除</p></div><button onClick={onEnterOrders}>查看全部</button></div><table><thead><tr><th>订单编号</th><th>业务员</th><th>事件类型</th><th>记账月</th><th>金额</th><th>组织归属</th><th>状态</th></tr></thead><tbody>{data?.recent.map((event) => <tr key={`${event.orderNo}-${event.month}-${event.amount}`}><td>{event.orderNo}</td><td>{event.salespersonName}</td><td>{eventTypeName(event.eventType)}</td><td>{event.month}</td><td className={Number(event.amount)<0?"negative":""}>{formatMoney(event.amount)}</td><td>{event.groupName}</td><td>已入账</td></tr>)}</tbody></table></section>
     </main>;
+}
+
+function AnalysisPanel(){
+  const[month,setMonth]=useState(businessDateToday().slice(0,7));
+  const[data,setData]=useState<PerformanceAnalysis|null>(null);
+  const[error,setError]=useState("");
+  const[revision,setRevision]=useState(0);
+  useEffect(()=>{const controller=new AbortController();setData(null);setError("");fetch(`/api/performance/analysis?month=${month}`,{signal:controller.signal}).then(async(response)=>{const result=await readResponseJson<PerformanceAnalysis&{message?:string}>(response,"分析服务响应无效");if(!response.ok)throw new Error(result.message??"分析加载失败");setData(result);}).catch((failure)=>{if(failure instanceof DOMException&&failure.name==="AbortError")return;setError(failure instanceof Error?failure.message:"分析加载失败");});return()=>controller.abort();},[month,revision]);
+  return <section className="analysis-panel" aria-labelledby="analysis-title"><div className="analysis-header"><div><h2 id="analysis-title">地区与客户单位分析</h2><p>只按事件发生时的不可变分析维度快照汇总，不使用订单当前资料</p></div><label><span>分析月份</span><input type="month" value={month} onChange={(event)=>setMonth(event.target.value)}/></label></div>
+    {error?<div className="query-feedback"><p className="page-message" role="alert">{error}</p><button type="button" onClick={()=>setRevision((value)=>value+1)}>重试查询</button></div>:null}
+    {!data&&!error?<p className="analysis-loading" role="status">正在读取地区与客户单位分析…</p>:null}
+    {data?<><section className="metric-band analysis-metrics"><Metric label="授权范围总账" value={formatMoney(data.ledger.totalAmount)} note={`${data.ledger.eventCount} 条事件`}/><Metric label="已映射" value={formatMoney(data.mapped.totalAmount)} note={`${data.mapped.eventCount} 条可信维度事件`}/><Metric label="待补齐" value={formatMoney(data.pending.totalAmount)} note={`${data.pending.eventCount} 条缺少可信维度事件`} warning/></section><p className={`analysis-reconciliation ${data.reconciled?"":"analysis-reconciliation-error"}`}>{data.reconciled?"已映射金额 + 待补齐金额与授权范围总账完全对平。":"分析维度对账失败，请停止使用当前汇总。"}</p><div className="analysis-grid"><article className="analysis-card"><h3>省份汇总</h3><div className="orders-table-wrap"><table aria-label="省份汇总"><thead><tr><th>省份</th><th>事件</th><th>金额</th></tr></thead><tbody>{data.provinces.length?data.provinces.map((item)=><tr key={item.regionCode}><td>{item.regionName}</td><td>{item.eventCount}</td><td className={Number(item.totalAmount)<0?"negative":""}>{formatMoney(item.totalAmount)}</td></tr>):<tr><td colSpan={3} className="empty-cell">本月没有已映射省份事件。</td></tr>}</tbody></table></div><div className="analysis-foreign"><div><strong>外贸（EXT-TRADE）</strong><span>独立区域，不进入省份统计</span></div><b className={Number(data.foreignTrade.totalAmount)<0?"negative":""}>{data.foreignTrade.eventCount} 条事件 · {formatMoney(data.foreignTrade.totalAmount)}</b></div></article><article className="analysis-card"><h3>客户单位汇总</h3><div className="orders-table-wrap"><table aria-label="客户单位汇总"><thead><tr><th>区域</th><th>客户单位</th><th>事件</th><th>金额</th></tr></thead><tbody>{data.customers.length?data.customers.map((item)=><tr key={`${item.regionCode}:${item.customerUnit}`}><td>{item.regionName}</td><td>{item.customerUnit}</td><td>{item.eventCount}</td><td className={Number(item.totalAmount)<0?"negative":""}>{formatMoney(item.totalAmount)}</td></tr>):<tr><td colSpan={4} className="empty-cell">本月没有已映射客户单位事件。</td></tr>}</tbody></table></div></article></div></>:null}
+  </section>;
 }
 
 function OrdersPage({ user }: { user: User }) {
@@ -570,7 +586,13 @@ function AchievementMembers({members}:{members:GroupAchievementMember[]}){
     </div>)}
   </section>)}</>;
 }
-function formatMoney(value: string | number) { return new Intl.NumberFormat("zh-CN", { style: "currency", currency: "CNY", minimumFractionDigits: 2 }).format(Number(value)); }
+function formatMoney(value: string | number) {
+  if(typeof value==="string"){
+    const decimal=/^(-?)(\d+)(?:\.(\d{1,2}))?$/.exec(value);
+    if(decimal)return `${decimal[1]}¥${new Intl.NumberFormat("zh-CN").format(BigInt(decimal[2]!))}.${(decimal[3]??"").padEnd(2,"0")}`;
+  }
+  return new Intl.NumberFormat("zh-CN", { style: "currency", currency: "CNY", minimumFractionDigits: 2 }).format(Number(value));
+}
 function formatOperationTime(value:string){return new Intl.DateTimeFormat("zh-CN",{timeZone:"Asia/Shanghai",year:"numeric",month:"2-digit",day:"2-digit",hour:"2-digit",minute:"2-digit",second:"2-digit",hour12:false}).format(new Date(value));}
 function eventTypeName(type: string) { return ({ initial:"首次录入", revenue_change:"营业额修改", pause:"整单暂停", restart:"订单重启", first_include:"首次计入", legacy_adjustment:"历史迁移",historical_review_resolution:"历史核对解析" } as Record<string,string>)[type] ?? type; }
 function businessRegionName(code:string){return standardBusinessRegions.find(([value])=>value===code)?.[1]??code;}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -261,6 +261,25 @@ form button:disabled { cursor: wait; opacity: .72; }
 .events-panel { margin-top: 20px; overflow: auto; }
 .events-panel .panel-title { padding: 20px 22px 15px; }
 .events-panel .panel-title button { border: 0; color: var(--blue); background: transparent; cursor: pointer; }
+.analysis-panel { margin-top: 20px; border: 1px solid var(--line); background: #fff; }
+.analysis-header { min-height: 78px; padding: 16px 22px; display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+.analysis-header h2, .analysis-card h3 { margin: 0; font-size: 16px; }
+.analysis-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; }
+.analysis-header label { width: 180px; margin: 0; }
+.analysis-header label span { display: block; margin-bottom: 6px; color: var(--muted); font-size: 12px; }
+.analysis-header input { height: 40px; }
+.analysis-metrics { margin-top: 0; grid-template-columns: repeat(3,1fr); border-right: 0; border-left: 0; }
+.analysis-reconciliation { margin: 0; padding: 12px 22px; color: #147465; background: #eaf7f4; font-size: 13px; }
+.analysis-reconciliation-error { color: #a63232; background: #fdeaea; }
+.analysis-loading { margin: 0; padding: 28px 22px; border-top: 1px solid var(--line); color: var(--muted); }
+.analysis-grid { display: grid; grid-template-columns: minmax(320px,.8fr) minmax(0,1.2fr); }
+.analysis-card { min-width: 0; border-top: 1px solid var(--line); }
+.analysis-card + .analysis-card { border-left: 1px solid var(--line); }
+.analysis-card h3 { padding: 18px 22px; }
+.analysis-foreign { min-height: 72px; padding: 14px 22px; border-top: 1px solid var(--line); display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.analysis-foreign div { display: grid; gap: 4px; }
+.analysis-foreign strong, .analysis-foreign b { font-size: 13px; }
+.analysis-foreign span { color: var(--muted); font-size: 11px; }
 .personal-drilldown { padding: 0 0 22px; }
 .personal-drilldown table { min-width: 800px; }
 .team-achievement { overflow: hidden; }
@@ -469,6 +488,9 @@ th { color: #68778a; background: #fafbfc; font-weight: 600; }
   .metric { border-right: 0; border-bottom: 1px solid var(--line); }
   .metric:last-child { border-bottom: 0; }
   .dashboard-grid { grid-template-columns: 1fr; }
+  .analysis-header { align-items: flex-start; }
+  .analysis-grid { grid-template-columns: 1fr; }
+  .analysis-card + .analysis-card { border-left: 0; }
   .org-grid { grid-template-columns: 1fr; }
   .governance-grid, .governance-lists { grid-template-columns: 1fr; }
   .events-panel { max-width: 100%; }


### PR DESCRIPTION
## 变更

- 新增按月份、权限范围汇总的地区与客户单位分析 API。
- 使用事件发生时的分析维度快照；省份、外贸、客户单位和待补齐分别展示并精确对账。
- 新增桌面总览分析面板、真实 PostgreSQL/浏览器验收及固定查询预算回归。
- 修正大额十进制金额在 Web 端的分币精度，并消除月份切换时的旧数据残留。

## 验证

- API：137/137
- Playwright：19/19
- 类型检查、生产构建、npm audit、Compose 配置通过
- 规格审查：CLEAN
- 工程标准审查：CLEAN

Closes #47