### PR TITLE
[P1][TB-17] 分域审计查询

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,6 +9,7 @@ import { registerGoals } from "./modules/goals.js";
 import { registerPerformance } from "./modules/performance.js";
 import { registerAccountingPeriods } from "./modules/accounting-periods.js";
 import { registerImports } from "./modules/imports.js";
+import { registerAudits } from "./modules/audits.js";
 
 type BuildAppOptions = {
   clock?: () => Date;
@@ -52,6 +53,7 @@ export async function buildApp(options: BuildAppOptions = {}) {
   await registerImports(app, database);
   await registerGoals(app, database);
   await registerAdmin(app, database);
+  await registerAudits(app, database);
   await registerExports(app, database, options.clock);
 
   app.get("/api/health", async () => ({

--- a/apps/api/src/audit-query.integration.test.ts
+++ b/apps/api/src/audit-query.integration.test.ts
@@ -1,0 +1,322 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+import { seedTestUser } from "./test-support/fixtures.js";
+import { withTestApi } from "./test-support/test-api.js";
+import { withMigratedTestDatabase } from "./test-support/test-database.js";
+
+const { Client } = pg;
+const TEST_ORIGIN = "http://127.0.0.1:4174";
+const apiRoot = fileURLToPath(new URL("../", import.meta.url));
+
+type AuditRow = Readonly<{
+  action: string;
+  actorDisplayName: string | null;
+  afterData: unknown;
+  entityId: string | null;
+  entityType: string;
+  id: string;
+}>;
+
+async function loginCookie(app: Parameters<Parameters<typeof withTestApi>[1]>[0], username: string): Promise<string> {
+  const response = await app.inject({
+    method: "POST",
+    url: "/api/auth/login",
+    headers: { origin: TEST_ORIGIN },
+    payload: { username, password: "Audit@123" },
+  });
+  assert.equal(response.statusCode, 200, response.body);
+  const cookies = Array.isArray(response.headers["set-cookie"])
+    ? response.headers["set-cookie"]
+    : [String(response.headers["set-cookie"])];
+  return cookies.map((value) => String(value).split(";", 1)[0]).join("; ");
+}
+
+async function seedAuditScenario(databaseUrl: string) {
+  const users = {
+    admin: await seedTestUser(databaseUrl, { username: "audit_admin", displayName: "审计系统管理员", password: "Audit@123", roleCode: "system_admin", roleName: "系统管理员" }),
+    hr: await seedTestUser(databaseUrl, { username: "audit_hr", displayName: "审计人事", password: "Audit@123", roleCode: "hr", roleName: "人事部" }),
+    generalManager: await seedTestUser(databaseUrl, { username: "audit_gm", displayName: "审计总经理", password: "Audit@123", roleCode: "general_manager", roleName: "总经理" }),
+    leader: await seedTestUser(databaseUrl, { username: "audit_leader", displayName: "审计甲组组长", password: "Audit@123", roleCode: "sales_leader", roleName: "业务员组长" }),
+    alice: await seedTestUser(databaseUrl, { username: "audit_alice", displayName: "审计业务员甲", password: "Audit@123", roleCode: "salesperson", roleName: "业务员" }),
+    bob: await seedTestUser(databaseUrl, { username: "audit_bob", displayName: "审计乙组组长", password: "Audit@123", roleCode: "sales_leader", roleName: "业务员组长" }),
+  };
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+  try {
+    const peopleResult = await client.query<{ person_id: string; user_id: string }>(
+      "select user_id::text,p.id::text as person_id from people p where user_id=any($1::bigint[])",
+      [Object.values(users)],
+    );
+    const people = Object.fromEntries(peopleResult.rows.map((row) => [row.user_id, row.person_id])) as Record<string, string>;
+    const departmentA = await client.query<{ id: string }>("insert into org_units(name,unit_type) values('审计甲部','department') returning id::text");
+    const departmentB = await client.query<{ id: string }>("insert into org_units(name,unit_type) values('审计乙部','department') returning id::text");
+    const groupA = await client.query<{ id: string }>("insert into org_units(name,unit_type,parent_id) values('审计甲组','group',$1) returning id::text", [departmentA.rows[0]!.id]);
+    const groupB = await client.query<{ id: string }>("insert into org_units(name,unit_type,parent_id) values('审计乙组','group',$1) returning id::text", [departmentB.rows[0]!.id]);
+    await client.query(
+      `insert into org_responsibilities(person_id,org_unit_id,responsibility_type,effective_from)
+       values($1,$2,'leader',current_date-60),($3,$4,'leader',current_date-60),
+             ($5,$6,'supervisor',current_date-60),($5,$7,'supervisor',current_date-60)`,
+      [people[users.leader], groupA.rows[0]!.id, people[users.bob], groupB.rows[0]!.id, people[users.admin], departmentA.rows[0]!.id, departmentB.rows[0]!.id],
+    );
+    await client.query(
+      `insert into org_memberships(person_id,department_id,group_id,effective_from,effective_to)
+       values($1,$2,$3,current_date-60,current_date-1),($1,$4,$5,current_date,null),
+             ($6,$4,$5,current_date-60,current_date-1),($6,$2,$3,current_date,null)`,
+      [people[users.alice], departmentA.rows[0]!.id, groupA.rows[0]!.id, departmentB.rows[0]!.id, groupB.rows[0]!.id, people[users.bob]],
+    );
+
+    const orders: string[] = [];
+    for (const [index, snapshot] of [
+      { userId: users.alice, personId: people[users.alice]!, name: "审计业务员甲", departmentId: departmentA.rows[0]!.id, departmentName: "审计甲部", groupId: groupA.rows[0]!.id, groupName: "审计甲组" },
+      { userId: users.bob, personId: people[users.bob]!, name: "审计业务员乙", departmentId: departmentB.rows[0]!.id, departmentName: "审计乙部", groupId: groupB.rows[0]!.id, groupName: "审计乙组" },
+    ].entries()) {
+      const order = await client.query<{ id: string }>(
+        `insert into performance_orders(qingflow_order_no,customer_name,customer_unit,salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+         values($1,$2,'审计测试单位',$3,$2,current_date-30,100,100,100,'active',now()) returning id::text`,
+        [`AUDIT-${index + 1}`, snapshot.name, snapshot.personId],
+      );
+      orders.push(order.rows[0]!.id);
+      await client.query(
+        `insert into performance_events(order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,
+          salesperson_person_id,salesperson_name,department_unit_id,department_name,group_unit_id,group_name,leader_name,supervisor_name,created_at)
+         values($1,'initial',100,100,100,date_trunc('month',current_date)::date,current_date-30,'审计范围测试',$2,$3,$4,$5,$6,$7,'审计组长','审计主管',now()-interval '10 minutes')`,
+        [order.rows[0]!.id, snapshot.personId, snapshot.name, snapshot.departmentId, snapshot.departmentName, snapshot.groupId, snapshot.groupName],
+      );
+    }
+
+    const parentGoal = await client.query<{ id: string }>(
+      `insert into goals(period_month,goal_level,owner_user_id,owner_person_id,org_unit_id)
+       values(date_trunc('month',current_date)::date,'group',$1,$2,$3) returning id::text`,
+      [users.leader, people[users.leader], groupA.rows[0]!.id],
+    );
+    const goal = await client.query<{ id: string }>(
+      `insert into goals(period_month,goal_level,owner_user_id,owner_person_id,parent_goal_id)
+       values(date_trunc('month',current_date)::date,'personal',$1,$2,$3) returning id::text`,
+      [users.alice, people[users.alice], parentGoal.rows[0]!.id],
+    );
+    const version = await client.query<{ id: string }>(
+      `insert into goal_versions(goal_id,version_no,amount,status,created_by,created_by_person_id,change_reason)
+       values($1,1,1000,'active',$2,$3,'审计查询测试') returning id::text`,
+      [goal.rows[0]!.id, users.leader, people[users.leader]],
+    );
+    const linkage = await client.query<{ id: string }>(
+      `insert into goal_linkage_decisions(parent_goal_id,triggering_child_version_id,status)
+       values($1,$2,'pending') returning id::text`,
+      [parentGoal.rows[0]!.id, version.rows[0]!.id],
+    );
+
+    await client.query(
+      `insert into audit_logs(actor_user_id,action,entity_type,entity_id,after_data,created_at) values
+       ($1::bigint,'auth.account_created','user',$1::text,null,now()-interval '6 minutes'),
+       ($1::bigint,'organization.unit_created','org_unit',$2::text,null,now()-interval '5 minutes'),
+       ($3::bigint,'performance.order_posted','performance_order',$4::text,$5::jsonb,now()-interval '4 minutes'),
+       ($6::bigint,'performance.order_posted','performance_order',$7::text,null,now()-interval '3 minutes'),
+       ($8::bigint,'goal.version_created','goal_version',$9::text,null,now()-interval '2 minutes'),
+       ($8::bigint,'goal.linkage_requested','goal_linkage_decision',$10::text,null,now()-interval '90 seconds'),
+       ($3::bigint,'performance.order_posted','performance_order','9223372036854775808',null,now()-interval '1 minute')`,
+      [
+        users.admin,
+        groupA.rows[0]!.id,
+        users.alice,
+        orders[0],
+        JSON.stringify({ customer: "可见业务数据", password: "PASSWORD-CANARY", nested: { temporaryPassword: "TEMP-CANARY", token: "TOKEN-CANARY" } }),
+        users.bob,
+        orders[1],
+        users.leader,
+        version.rows[0]!.id,
+        linkage.rows[0]!.id,
+      ],
+    );
+    return { orders, users };
+  } finally {
+    await client.end();
+  }
+}
+
+test("审计查询按管理域、业务域和事件组织快照隔离", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    const scenario = await seedAuditScenario(database.url);
+    await withTestApi(database.url, async (app) => {
+      const adminCookie = await loginCookie(app, "audit_admin");
+      const admin = await app.inject({ method: "GET", url: "/api/audits", headers: { cookie: adminCookie } });
+      assert.equal(admin.statusCode, 200, admin.body);
+      assert.deepEqual(admin.json<{ audits: AuditRow[] }>().audits.map((row) => row.action).sort(), ["auth.account_created", "auth.login_succeeded", "organization.unit_created"]);
+
+      const roleClient = new Client({ connectionString: database.url });
+      await roleClient.connect();
+      try {
+        await roleClient.query("insert into user_roles(user_id,role_code) values($1,'hr')", [scenario.users.admin]);
+      } finally {
+        await roleClient.end();
+      }
+      const combined = await app.inject({ method: "GET", url: "/api/audits", headers: { cookie: adminCookie } });
+      assert.equal(combined.statusCode, 200, combined.body);
+      assert.deepEqual(new Set(combined.json<{ audits: AuditRow[] }>().audits.map((row) => row.action)), new Set(["auth.account_created", "auth.login_succeeded", "organization.unit_created", "goal.version_created", "goal.linkage_requested", "performance.order_posted"]));
+
+      for (const username of ["audit_hr", "audit_gm"]) {
+        const cookie = await loginCookie(app, username);
+        const response = await app.inject({ method: "GET", url: "/api/audits", headers: { cookie } });
+        assert.equal(response.statusCode, 200, response.body);
+        const rows = response.json<{ audits: AuditRow[] }>().audits;
+        assert.deepEqual(rows.map((row) => row.action).sort(), ["goal.linkage_requested", "goal.version_created", "performance.order_posted", "performance.order_posted"]);
+        assert.doesNotMatch(JSON.stringify(rows), /PASSWORD-CANARY|TEMP-CANARY|TOKEN-CANARY|password|temporaryPassword|token/);
+      }
+
+      const leaderCookie = await loginCookie(app, "audit_leader");
+      const leader = await app.inject({ method: "GET", url: "/api/audits", headers: { cookie: leaderCookie } });
+      assert.equal(leader.statusCode, 200, leader.body);
+      const leaderRows = leader.json<{ audits: AuditRow[] }>().audits;
+      assert.equal(leaderRows.some((row) => row.entityId === scenario.orders[0]), true, "移出当前小组后，历史事件仍按发生时甲组快照可见");
+      assert.equal(leaderRows.some((row) => row.entityId === scenario.orders[1]), false, "当前调入甲组不能扩大乙组历史事件权限");
+      assert.equal(leaderRows.some((row) => row.action === "goal.version_created"), true);
+      assert.equal(leaderRows.some((row) => row.action === "goal.linkage_requested"), true);
+
+      const bobCookie = await loginCookie(app, "audit_bob");
+      const bob = await app.inject({ method: "GET", url: "/api/audits", headers: { cookie: bobCookie } });
+      assert.equal(bob.statusCode, 200, bob.body);
+      const bobRows = bob.json<{ audits: AuditRow[] }>().audits;
+      assert.equal(bobRows.some((row) => row.entityId === scenario.orders[1]), true);
+      assert.equal(bobRows.some((row) => row.action === "goal.version_created"), false, "人员当前调入乙组不能扩大乙组组长的历史目标审计权限");
+      assert.equal(bobRows.some((row) => row.action === "goal.linkage_requested"), false);
+
+      const aliceCookie = await loginCookie(app, "audit_alice");
+      const exported = await app.inject({ method: "GET", url: "/api/exports/performance.csv", headers: { cookie: aliceCookie } });
+      assert.equal(exported.statusCode, 200, exported.body);
+      assert.doesNotMatch(exported.body, /PASSWORD-CANARY|TEMP-CANARY|TOKEN-CANARY/);
+      const aliceAudit = await app.inject({ method: "GET", url: "/api/audits?action=performance.order_export", headers: { cookie: aliceCookie } });
+      assert.equal(aliceAudit.statusCode, 200, aliceAudit.body);
+      assert.equal(aliceAudit.json<{ audits: AuditRow[] }>().audits.some((row) => row.entityType === "order_export" && row.actorDisplayName === "审计业务员甲"), true);
+      const aliceLinkage = await app.inject({ method: "GET", url: "/api/audits?action=goal.linkage_requested", headers: { cookie: aliceCookie } });
+      assert.equal(aliceLinkage.statusCode, 200, aliceLinkage.body);
+      assert.equal(aliceLinkage.json<{ audits: AuditRow[] }>().audits.length, 1, "子目标责任人可见由本人目标版本触发的联动审计");
+    });
+  });
+});
+
+test("审计查询支持人员、动作、实体、时间和稳定游标过滤", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    const scenario = await seedAuditScenario(database.url);
+    await withTestApi(database.url, async (app) => {
+      const cookie = await loginCookie(app, "audit_hr");
+      const pageClient = new Client({ connectionString: database.url });
+      await pageClient.connect();
+      try {
+        await pageClient.query(
+          `insert into audit_logs(actor_user_id,action,entity_type,entity_id)
+           select $1,'performance.cursor_test','performance_order',$2::text from generate_series(1,51)`,
+          [scenario.users.alice, scenario.orders[0]],
+        );
+      } finally {
+        await pageClient.end();
+      }
+      const firstPage = await app.inject({ method: "GET", url: "/api/audits?action=performance.cursor_test", headers: { cookie } });
+      assert.equal(firstPage.statusCode, 200, firstPage.body);
+      const firstData = firstPage.json<{ audits: AuditRow[]; nextCursor: string | null }>();
+      assert.equal(firstData.audits.length, 50);
+      assert.ok(firstData.nextCursor);
+      const concurrentClient = new Client({ connectionString: database.url });
+      await concurrentClient.connect();
+      let concurrentId: string;
+      try {
+        const inserted = await concurrentClient.query<{ id: string }>(
+          "insert into audit_logs(actor_user_id,action,entity_type,entity_id) values($1,'performance.cursor_test','performance_order',$2) returning id::text",
+          [scenario.users.alice, scenario.orders[0]],
+        );
+        concurrentId = inserted.rows[0]!.id;
+      } finally {
+        await concurrentClient.end();
+      }
+      const cursorPage = await app.inject({ method: "GET", url: `/api/audits?action=performance.cursor_test&cursor=${firstData.nextCursor}`, headers: { cookie } });
+      assert.equal(cursorPage.statusCode, 200, cursorPage.body);
+      const secondRows = cursorPage.json<{ audits: AuditRow[] }>().audits;
+      assert.equal(secondRows.length, 1);
+      const traversedIds = [...firstData.audits, ...secondRows].map((row) => row.id);
+      assert.equal(new Set(traversedIds).size, 51);
+      assert.equal(traversedIds.includes(concurrentId), false);
+
+      const query = new URLSearchParams({ person: "审计业务员甲", action: "performance.order_posted", entityType: "performance_order", entityId: scenario.orders[0]! });
+      const response = await app.inject({ method: "GET", url: `/api/audits?${query}`, headers: { cookie } });
+      assert.equal(response.statusCode, 200, response.body);
+      const rows = response.json<{ audits: AuditRow[]; nextCursor: string | null }>().audits;
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]!.actorDisplayName, "审计业务员甲");
+      assert.equal(rows[0]!.entityId, scenario.orders[0]);
+
+      const empty = await app.inject({ method: "GET", url: "/api/audits?to=2000-01-01T00%3A00%3A00.000Z", headers: { cookie } });
+      assert.equal(empty.statusCode, 200, empty.body);
+      assert.equal(empty.json<{ audits: AuditRow[] }>().audits.length, 0);
+      const invalid = await app.inject({ method: "GET", url: "/api/audits?from=2026-09-02T00%3A00%3A00.000Z&to=2026-09-01T00%3A00%3A00.000Z", headers: { cookie } });
+      assert.equal(invalid.statusCode, 400, invalid.body);
+    });
+  });
+});
+
+test("审计凭据 canary 不进入真实服务日志或业务 CSV", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    await seedAuditScenario(database.url);
+    const api = spawn(process.execPath, ["--import", "tsx", "src/server.ts"], {
+      cwd: apiRoot,
+      env: { ...process.env, API_PORT: "3103", DATABASE_URL: database.runtimeUrl, NODE_ENV: "test" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let logs = "";
+    api.stdout.setEncoding("utf8");
+    api.stderr.setEncoding("utf8");
+    api.stdout.on("data", (chunk: string) => { logs += chunk; });
+    api.stderr.on("data", (chunk: string) => { logs += chunk; });
+    try {
+      let ready = false;
+      const deadline = Date.now() + 15_000;
+      while (Date.now() < deadline) {
+        try {
+          const response = await fetch("http://127.0.0.1:3103/api/ready");
+          if (response.ok) { ready = true; break; }
+        } catch {
+          // 服务尚未监听时继续等待。
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      assert.equal(ready, true, logs);
+      const login = await fetch("http://127.0.0.1:3103/api/auth/login", {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: TEST_ORIGIN },
+        body: JSON.stringify({ username: "audit_hr", password: "Audit@123" }),
+      });
+      assert.equal(login.status, 200, await login.text());
+      const cookie = login.headers.get("set-cookie")?.match(/sampleflow_session=[^;,]+/)?.[0];
+      assert.ok(cookie);
+      const audit = await fetch("http://127.0.0.1:3103/api/audits", { headers: { cookie } });
+      assert.equal(audit.status, 200);
+      assert.doesNotMatch(await audit.text(), /PASSWORD-CANARY|TEMP-CANARY|TOKEN-CANARY/);
+      const csv = await fetch("http://127.0.0.1:3103/api/exports/performance.csv", { headers: { cookie } });
+      assert.equal(csv.status, 200);
+      assert.doesNotMatch(await csv.text(), /PASSWORD-CANARY|TEMP-CANARY|TOKEN-CANARY/);
+    } finally {
+      if (api.exitCode === null) {
+        api.kill();
+        await once(api, "exit");
+      }
+    }
+    assert.doesNotMatch(logs, /PASSWORD-CANARY|TEMP-CANARY|TOKEN-CANARY/);
+  });
+});
+
+test("审计日志在数据库层拒绝更新和删除", async () => {
+  await withMigratedTestDatabase(async (database) => {
+    const client = new Client({ connectionString: database.url });
+    await client.connect();
+    try {
+      const inserted = await client.query<{ id: string }>("insert into audit_logs(action,entity_type) values('audit.immutable_test','test') returning id::text");
+      await assert.rejects(client.query("update audit_logs set action='audit.changed' where id=$1", [inserted.rows[0]!.id]), /审计日志不可更新或删除/);
+      await assert.rejects(client.query("delete from audit_logs where id=$1", [inserted.rows[0]!.id]), /审计日志不可更新或删除/);
+      const remaining = await client.query<{ action: string }>("select action from audit_logs where id=$1", [inserted.rows[0]!.id]);
+      assert.equal(remaining.rows[0]?.action, "audit.immutable_test");
+    } finally {
+      await client.end();
+    }
+  });
+});

--- a/apps/api/src/modules/audits.ts
+++ b/apps/api/src/modules/audits.ts
@@ -1,0 +1,138 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import type { Database } from "../db.js";
+import { postgresBigintIdSchema } from "../validation.js";
+import { canReadGoals, canReadPerformance, performanceScopeSql, performanceScopeValues, resolveGoalAccess, resolvePerformanceAccess } from "./authorization.js";
+
+const querySchema = z.strictObject({
+  person: z.string().trim().max(100).optional().default(""),
+  action: z.string().trim().max(100).optional().default(""),
+  entityType: z.string().trim().max(100).optional().default(""),
+  entityId: z.string().trim().max(100).optional().default(""),
+  from: z.iso.datetime({ offset: true }).optional(),
+  to: z.iso.datetime({ offset: true }).optional(),
+  cursor: postgresBigintIdSchema.optional(),
+});
+const PAGE_SIZE = 50;
+const SENSITIVE_FIELD = /password|token|secret|credential|authorization|cookie|session/i;
+
+function redact(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redact);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value).flatMap(([key, nested]) => SENSITIVE_FIELD.test(key) ? [] : [[key, redact(nested)]]));
+}
+
+export async function registerAudits(app: FastifyInstance, db: Database) {
+  app.get("/api/audits", async (request, reply) => {
+    if (!request.currentUser) return reply.code(401).send({ message: "尚未登录" });
+    const parsed = querySchema.safeParse(request.query);
+    if (!parsed.success || (parsed.data.from && parsed.data.to && Date.parse(parsed.data.from) > Date.parse(parsed.data.to))) {
+      return reply.code(400).send({ message: "审计查询条件无效" });
+    }
+
+    const systemAdmin = request.currentUser.roles.includes("system_admin");
+    const performanceAccess = await resolvePerformanceAccess(db, request.currentUser);
+    const goalAccess = await resolveGoalAccess(db, request.currentUser);
+    const performanceReader = canReadPerformance(performanceAccess);
+    if (!systemAdmin && !performanceReader && !canReadGoals(goalAccess)) {
+      return reply.code(403).send({ message: "当前角色没有审计查询权限" });
+    }
+    const filters = parsed.data;
+    const safeEntityId = "case when audit.entity_id ~ '^[1-9][0-9]{0,18}$' and (length(audit.entity_id)<19 or audit.entity_id<='9223372036854775807') then audit.entity_id::bigint end";
+    const result = await db.query<{
+      action: string;
+      actorDisplayName: string | null;
+      actorPersonId: string | null;
+      actorUsername: string | null;
+      afterData: unknown;
+      beforeData: unknown;
+      createdAt: Date;
+      entityId: string | null;
+      entityType: string;
+      id: string;
+    }>(
+      `select audit.id::text,
+              actor_person.id::text as "actorPersonId",actor_user.username as "actorUsername",actor_user.display_name as "actorDisplayName",
+              audit.action,audit.entity_type as "entityType",audit.entity_id as "entityId",
+              audit.before_data as "beforeData",audit.after_data as "afterData",audit.created_at as "createdAt"
+       from audit_logs audit
+       left join users actor_user on actor_user.id=audit.actor_user_id
+       left join people actor_person on actor_person.user_id=actor_user.id
+       where (
+         ($1::boolean and (audit.action like 'auth.%' or audit.action like 'organization.%'))
+         or ((audit.action like 'goal.%' or audit.action like 'performance.%' or audit.action like 'accounting.%' or audit.action like 'import.%') and (
+           exists(
+             select 1 from goals scoped_goal
+             left join goals parent_goal on parent_goal.id=scoped_goal.parent_goal_id
+             left join goals grandparent_goal on grandparent_goal.id=parent_goal.parent_goal_id
+             where ($2::boolean
+               or scoped_goal.owner_person_id=any($3::bigint[])
+               or scoped_goal.org_unit_id=any($4::bigint[]) or parent_goal.org_unit_id=any($4::bigint[]) or grandparent_goal.org_unit_id=any($4::bigint[])
+               or scoped_goal.org_unit_id=any($5::bigint[]) or parent_goal.org_unit_id=any($5::bigint[]) or grandparent_goal.org_unit_id=any($5::bigint[])
+             ) and (
+               (audit.entity_type='goal' and scoped_goal.id=${safeEntityId})
+               or (audit.entity_type='goal_version' and exists(select 1 from goal_versions version_row where version_row.id=${safeEntityId} and version_row.goal_id=scoped_goal.id))
+               or (audit.entity_type='goal_change_request' and exists(select 1 from goal_change_requests request_row where request_row.id=${safeEntityId} and request_row.goal_id=scoped_goal.id))
+               or (audit.entity_type='goal_linkage_decision' and exists(
+                 select 1 from goal_linkage_decisions linkage_row
+                 left join goal_versions child_version on child_version.id=linkage_row.triggering_child_version_id
+                 where linkage_row.id=${safeEntityId} and (linkage_row.parent_goal_id=scoped_goal.id or child_version.goal_id=scoped_goal.id)
+               ))
+             )
+           )
+           or exists(
+             select 1 from performance_events scoped_event
+             where ${performanceScopeSql("scoped_event", 6)} and (
+               (audit.entity_type='performance_event' and scoped_event.id=${safeEntityId})
+               or scoped_event.id=(
+                 select latest_event.id from performance_events latest_event
+                 where latest_event.order_id=case audit.entity_type
+                   when 'performance_order' then ${safeEntityId}
+                   when 'accounting_correction' then (select correction.order_id from accounting_correction_requests correction where correction.id=${safeEntityId})
+                   when 'historical_order_review' then (select review.order_id from historical_order_reviews review where review.id=${safeEntityId})
+                 end
+                   and latest_event.created_at<=audit.created_at
+                 order by latest_event.order_sequence desc,latest_event.id desc limit 1
+               )
+             )
+           )
+           or ($6::boolean and audit.entity_type in ('accounting_period','import_config','import_batch'))
+           or ($18::boolean and audit.entity_type='order_export' and ($6::boolean or audit.actor_user_id=$17::bigint))
+         ))
+       )
+         and ($10='' or position(lower($10) in lower(coalesce(actor_user.username,'')||' '||coalesce(actor_user.display_name,'')||' '||coalesce(actor_person.id::text,'')))>0)
+         and ($11='' or position(lower($11) in lower(audit.action))>0)
+         and ($12='' or audit.entity_type=$12)
+         and ($13='' or coalesce(audit.entity_id,'')=$13)
+         and ($14::timestamptz is null or audit.created_at>=$14::timestamptz)
+         and ($15::timestamptz is null or audit.created_at<=$15::timestamptz)
+         and ($16::bigint is null or audit.id<$16::bigint)
+       order by audit.id desc limit $19`,
+      [
+        systemAdmin,
+        goalAccess.all,
+        goalAccess.selfPersonIds,
+        goalAccess.groupIds,
+        goalAccess.departmentIds,
+        ...performanceScopeValues(performanceAccess),
+        filters.person,
+        filters.action,
+        filters.entityType,
+        filters.entityId,
+        filters.from ?? null,
+        filters.to ?? null,
+        filters.cursor ?? null,
+        request.currentUser.id,
+        performanceReader,
+        PAGE_SIZE + 1,
+      ],
+    );
+    const hasNext = result.rows.length > PAGE_SIZE;
+    const audits = result.rows.slice(0, PAGE_SIZE).map((row) => ({
+      ...row,
+      beforeData: redact(row.beforeData),
+      afterData: redact(row.afterData),
+    }));
+    return { audits, pageSize: PAGE_SIZE, nextCursor: hasNext ? audits.at(-1)!.id : null };
+  });
+}

--- a/apps/api/src/modules/authorization.ts
+++ b/apps/api/src/modules/authorization.ts
@@ -54,6 +54,7 @@ export function capabilitiesForRoles(roles: readonly string[]) {
   return {
     viewPerformance,
     viewGoals,
+    viewAudits: policies.length > 0,
     viewOrganization: viewPerformance || viewGoals || policies.some((policy) => policy.organizationAdmin),
     viewApprovals: viewGoals,
     editPerformance: policies.some((policy) => policy.performanceEdit),
@@ -112,15 +113,23 @@ export function performanceScopeValues(access: PerformanceAccess): unknown[] {
   return [access.all, access.personIds, access.groupIds, access.departmentIds];
 }
 
-export type GoalAccess = Readonly<{ all: boolean; ownerPersonIds: string[] }>;
+export type GoalAccess = Readonly<{
+  all: boolean;
+  departmentIds: string[];
+  groupIds: string[];
+  ownerPersonIds: string[];
+  selfPersonIds: string[];
+}>;
 
 export async function resolveGoalAccess(database: QueryDatabase, user: CurrentUser): Promise<GoalAccess> {
   const scopes = new Set(policiesFor(user.roles).map((policy) => policy.goalScope));
-  if (scopes.has("all")) return { all: true, ownerPersonIds: [] };
+  if (scopes.has("all")) return { all: true, departmentIds: [], groupIds: [], ownerPersonIds: [], selfPersonIds: [] };
   const ownerPersonIds = new Set<string>();
-  if ([...scopes].some((scope) => ["self", "group", "department"].includes(scope))) ownerPersonIds.add(user.personId);
+  const selfPersonIds = [...scopes].some((scope) => ["self", "group", "department"].includes(scope)) ? [user.personId] : [];
+  for (const personId of selfPersonIds) ownerPersonIds.add(personId);
+  let performanceAccess: PerformanceAccess | null = null;
   if (scopes.has("group") || scopes.has("department")) {
-    const performanceAccess = await resolvePerformanceAccess(database, user);
+    performanceAccess = await resolvePerformanceAccess(database, user);
     const result = await database.query<{ person_id: string }>(
       `select distinct m.person_id::text
        from org_memberships m
@@ -133,7 +142,13 @@ export async function resolveGoalAccess(database: QueryDatabase, user: CurrentUs
     );
     for (const row of result.rows) ownerPersonIds.add(row.person_id);
   }
-  return { all: false, ownerPersonIds: [...ownerPersonIds] };
+  return {
+    all: false,
+    departmentIds: scopes.has("department") ? performanceAccess?.departmentIds ?? [] : [],
+    groupIds: scopes.has("group") ? performanceAccess?.groupIds ?? [] : [],
+    ownerPersonIds: [...ownerPersonIds],
+    selfPersonIds,
+  };
 }
 
 export function canReadGoals(access: GoalAccess): boolean {

--- a/apps/web/e2e/audits.spec.ts
+++ b/apps/web/e2e/audits.spec.ts
@@ -1,0 +1,69 @@
+import pg from "pg";
+import type { Page } from "@playwright/test";
+import { seedTestUser } from "../../api/src/test-support/fixtures.js";
+import { expect, test } from "./full-stack.js";
+
+const { Client } = pg;
+test.use({ timezoneId: "America/Los_Angeles" });
+
+async function login(page: Page, username: string) {
+  await page.goto("/");
+  await page.getByLabel("账号").fill(username);
+  await page.getByLabel("密码", { exact: true }).fill("Audits@123");
+  await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+}
+
+test("审计页面只读展示所属域并支持组合过滤", async ({ database, page }) => {
+  const adminId = await seedTestUser(database.url, { username: "e2e_audit_admin", displayName: "E2E 审计管理员", password: "Audits@123", roleCode: "system_admin", roleName: "系统管理员" });
+  await seedTestUser(database.url, { username: "e2e_audit_hr", displayName: "E2E 审计人事", password: "Audits@123", roleCode: "hr", roleName: "人事部" });
+  const actorId = await seedTestUser(database.url, { username: "e2e_audit_actor", displayName: "E2E 审计业务员", password: "Audits@123", roleCode: "salesperson", roleName: "业务员" });
+  const setup = new Client({ connectionString: database.url });
+  await setup.connect();
+  try {
+    const actor = await setup.query<{ id: string }>("select id::text from people where user_id=$1", [actorId]);
+    const order = await setup.query<{ id: string }>(
+      `insert into performance_orders(qingflow_order_no,customer_name,customer_unit,salesperson_person_id,salesperson_name,source_received_on,original_amount,current_revenue,counted_amount,lifecycle_state,posted_at)
+       values('E2E-AUDIT-1','E2E 审计客户','E2E 审计单位',$1,'E2E 审计业务员',current_date,100,100,100,'active',now()) returning id::text`,
+      [actor.rows[0]!.id],
+    );
+    await setup.query(
+      `insert into performance_events(order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,department_name,group_name)
+       values($1,'initial',100,100,100,date_trunc('month',current_date)::date,current_date,'E2E 审计事件',$2,'E2E 审计业务员','E2E 部门','E2E 小组')`,
+      [order.rows[0]!.id, actor.rows[0]!.id],
+    );
+    await setup.query(
+      `insert into audit_logs(actor_user_id,action,entity_type,entity_id,after_data,created_at) values
+       ($1::bigint,'auth.account_created','user',$1::text,null,'2026-09-01T12:29:00Z'),
+       ($1::bigint,'organization.unit_created','org_unit','9001',null,'2026-09-01T12:30:00Z'),
+       ($2::bigint,'performance.order_posted','performance_order',$3::text,$4::jsonb,'2026-09-01T12:31:00Z')`,
+      [adminId, actorId, order.rows[0]!.id, JSON.stringify({ customer: "E2E 审计客户", temporaryPassword: "E2E-TEMP-CANARY", token: "E2E-TOKEN-CANARY" })],
+    );
+
+    await login(page, "e2e_audit_admin");
+    await page.getByRole("button", { name: "审计查询" }).click();
+    await expect(page.getByRole("heading", { name: "审计查询" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: "auth.account_created" })).toBeVisible();
+    await expect(page.getByText("performance.order_posted", { exact: true })).not.toBeVisible();
+    await page.getByLabel("动作").fill("organization");
+    await page.getByRole("button", { name: "查询审计" }).click();
+    await expect(page.getByRole("cell", { name: "organization.unit_created" })).toBeVisible();
+    await expect(page.getByText("auth.account_created", { exact: true })).not.toBeVisible();
+    const organizationRow = page.getByRole("row").filter({ hasText: "organization.unit_created" });
+    await expect(organizationRow).toContainText(/2026.*9.*1.*20:30/);
+    await page.getByLabel("开始时间").fill("2026-09-01T20:00");
+    const timeRequest = page.waitForRequest((request) => new URL(request.url()).searchParams.has("from"));
+    await page.getByRole("button", { name: "查询审计" }).click();
+    expect(new URL((await timeRequest).url()).searchParams.get("from")).toBe("2026-09-01T20:00:00+08:00");
+    await expect(organizationRow).toBeVisible();
+    await expect(page.getByRole("button", { name: /修改|删除/ })).toHaveCount(0);
+
+    await page.getByRole("button", { name: "退出登录" }).click();
+    await login(page, "e2e_audit_hr");
+    await page.getByRole("button", { name: "审计查询" }).click();
+    await expect(page.getByRole("cell", { name: "performance.order_posted" })).toBeVisible();
+    await expect(page.getByText("auth.account_created", { exact: true })).not.toBeVisible();
+    await expect(page.getByText(/E2E-TEMP-CANARY|E2E-TOKEN-CANARY/)).toHaveCount(0);
+  } finally {
+    await setup.end();
+  }
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { Activity, BarChart3, ChevronRight, ClipboardCheck, Database, Eye, EyeOff, FileClock, FileUp, LogOut, Network, PauseCircle, PlayCircle, Plus, RefreshCw, Search, ShieldCheck, Target, UsersRound, X } from "lucide-react";
 import type { ChinaMap } from "./china-map";
 
-type Capabilities = { viewPerformance:boolean; viewGoals:boolean; viewOrganization:boolean; viewApprovals:boolean; editPerformance:boolean; exportPerformance:boolean; exportGoals:boolean; manageAccounts:boolean; manageOrganization:boolean };
+type Capabilities = { viewPerformance:boolean; viewGoals:boolean; viewAudits:boolean; viewOrganization:boolean; viewApprovals:boolean; editPerformance:boolean; exportPerformance:boolean; exportGoals:boolean; manageAccounts:boolean; manageOrganization:boolean };
 type User = { id: string; personId:string; username: string; displayName: string; mustChangePassword: boolean; roles: string[]; capabilities:Capabilities };
 type AuthState = { status: "loading" } | { status: "guest" } | { status: "authenticated"; user: User };
 type OrderLifecycle = "draft" | "active" | "paused" | "zero" | "historical_review_required";
@@ -55,6 +55,9 @@ type RolePermission = { code:string; name:string; businessScope:"none"|"self"|"g
 type OrgUnit = { id:string; name:string; unitType:"department"|"group"; parentId:string|null; parentName:string|null; isActive:boolean };
 type Assignment = { id:string; username:string; displayName:string; departmentName:string|null; groupName:string|null; effectiveFrom:string; effectiveTo:string|null };
 type Responsibility = { id:string; personId:string; username:string|null; displayName:string; unitId:string; unitName:string; unitType:"department"|"group"; responsibilityType:"leader"|"supervisor"; effectiveFrom:string; effectiveTo:string|null };
+type AuditRow = { id:string; actorPersonId:string|null; actorUsername:string|null; actorDisplayName:string|null; action:string; entityType:string; entityId:string|null; beforeData:unknown; afterData:unknown; createdAt:string };
+type AuditFilters = { person:string; action:string; entityType:string; entityId:string; from:string; to:string };
+const emptyAuditFilters:AuditFilters={person:"",action:"",entityType:"",entityId:"",from:"",to:""};
 const roleNames: Record<string, string> = { system_admin: "系统管理员", sales_assistant: "销售助理", sales_assistant_leader: "销售助理组长", sales_manager: "销售经理", sales_supervisor: "业务主管", sales_leader: "业务员组长", salesperson: "业务员", hr: "人事部", general_manager: "总经理" };
 function businessDateToday():string{const parts=new Intl.DateTimeFormat("zh-CN",{timeZone:"Asia/Shanghai",year:"numeric",month:"2-digit",day:"2-digit"}).formatToParts(new Date());const value=(type:Intl.DateTimeFormatPartTypes)=>parts.find((part)=>part.type===type)?.value??"";return `${value("year")}-${value("month")}-${value("day")}`;}
 
@@ -162,13 +165,14 @@ function Login({ onLogin }: { onLogin: (user: User) => void }) {
 }
 
 function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
-  type PageId = "overview"|"goals"|"orders"|"organization"|"approvals"|"accounts";
+  type PageId = "overview"|"goals"|"orders"|"organization"|"approvals"|"accounts"|"audits";
   const pages = [
     user.capabilities.viewPerformance ? {id:"overview" as const,Icon:BarChart3,label:"业绩总览"} : null,
     user.capabilities.viewGoals ? {id:"goals" as const,Icon:Target,label:"目标管理"} : null,
     user.capabilities.viewPerformance ? {id:"orders" as const,Icon:ClipboardCheck,label:"订单业绩"} : null,
     user.capabilities.viewOrganization ? {id:"organization" as const,Icon:Network,label:"组织架构"} : null,
     user.capabilities.viewApprovals ? {id:"approvals" as const,Icon:FileClock,label:"审批中心"} : null,
+    user.capabilities.viewAudits ? {id:"audits" as const,Icon:Search,label:"审计查询"} : null,
     user.capabilities.manageAccounts ? {id:"accounts" as const,Icon:UsersRound,label:"账号管理"} : null,
   ].filter((page):page is NonNullable<typeof page>=>page!==null);
   const defaultPage:PageId=user.capabilities.manageAccounts?"accounts":pages[0]?.id??"overview";
@@ -188,10 +192,26 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
         ? <GoalsPage user={user} pendingOnly />
       : active === "organization"
         ? <OrganizationPage user={user}/>
+      : active === "audits"
+        ? <AuditPage/>
       : active === "accounts"
         ? <AccountsPage user={user}/>
       : <Overview canEdit={user.capabilities.editPerformance} canExport={user.capabilities.exportPerformance} onEnterOrders={() => navigate("orders")} />;
   return <div className="app-shell"><aside className="sidebar"><div className="sidebar-brand"><img src="/brand-logo.png" alt="瑞源生物 Pronetbio"/></div><nav>{pages.map(({Icon,label,id}) => <button className={id === active ? "active" : ""} key={id} onClick={() => navigate(id)} aria-label={label} aria-current={id===active?"page":undefined}><Icon size={18}/><span>{label}</span></button>)}</nav><div className="sidebar-user"><div className="avatar">{user.displayName.slice(0,1)}</div><div><strong>{user.displayName}</strong><span>{user.roles.map((r) => roleNames[r] ?? r).join("、")}</span></div><button onClick={logout} aria-label="退出登录"><LogOut size={17}/></button></div></aside>{content}</div>;
+}
+
+function auditData(value:unknown):string{return value===null||value===undefined?"—":JSON.stringify(value);}
+function auditDateTime(value:string):string{return new Intl.DateTimeFormat("zh-CN",{dateStyle:"medium",timeStyle:"medium",timeZone:"Asia/Shanghai"}).format(new Date(value));}
+function auditTimeParameter(value:string):string{return value?`${value}${value.length===16?":00":""}+08:00`:"";}
+
+function AuditPage(){
+  const[draft,setDraft]=useState<AuditFilters>(emptyAuditFilters);const[filters,setFilters]=useState<AuditFilters>(emptyAuditFilters);const[audits,setAudits]=useState<AuditRow[]>([]);const[cursor,setCursor]=useState<string|null>(null);const[nextCursor,setNextCursor]=useState<string|null>(null);const[loading,setLoading]=useState(false);const[error,setError]=useState("");const[revision,setRevision]=useState(0);
+  const requestKey=JSON.stringify([filters,cursor,revision]);
+  useEffect(()=>{const controller=new AbortController();const params=new URLSearchParams();for(const key of ["person","action","entityType","entityId"] as const)if(filters[key])params.set(key,filters[key]);if(filters.from)params.set("from",auditTimeParameter(filters.from));if(filters.to)params.set("to",auditTimeParameter(filters.to));if(cursor)params.set("cursor",cursor);setLoading(true);setError("");setNextCursor(null);if(!cursor)setAudits([]);fetch(`/api/audits${params.size?`?${params.toString()}`:""}`,{signal:controller.signal}).then(async(response)=>{const data=await readResponseJson<{audits?:AuditRow[];nextCursor?:string|null;message?:string}>(response,"审计响应无效，请重试。");if(!response.ok)throw new Error(data.message??"审计查询失败");setAudits((current)=>cursor?[...current,...(data.audits??[])]:data.audits??[]);setNextCursor(data.nextCursor??null);}).catch((reason)=>{if(reason instanceof DOMException&&reason.name==="AbortError")return;setError(reason instanceof Error?reason.message:"审计查询失败");}).finally(()=>{if(!controller.signal.aborted)setLoading(false);});return()=>controller.abort();},[requestKey]);
+  function update(key:keyof AuditFilters,value:string){setDraft((current)=>({...current,[key]:value}));}
+  function query(event:FormEvent){event.preventDefault();setFilters(Object.fromEntries(Object.entries(draft).map(([key,value])=>[key,value.trim()])) as AuditFilters);setCursor(null);setRevision((value)=>value+1);}
+  function clear(){setDraft(emptyAuditFilters);setFilters(emptyAuditFilters);setCursor(null);setRevision((value)=>value+1);}
+  return <main className="dashboard"><header><div><h1>审计查询</h1><p>按账号、动作、实体和时间追溯不可变记录；数据范围沿用当前角色权限</p></div></header><div className="permission-note"><ShieldCheck size={18}/>此页面只提供查询，不提供修改或删除入口；敏感凭据字段不会返回。</div><section className="orders-card" aria-labelledby="audit-table-title"><div className="orders-toolbar"><div><h2 id="audit-table-title">审计记录</h2><span role="status">{loading?"正在查询…":`已加载 ${audits.length} 条记录`}</span></div></div><form noValidate className="order-filters" onSubmit={query}><div className="order-filter-grid"><label className="field"><span>人员</span><input value={draft.person} onChange={(event)=>update("person",event.target.value)} placeholder="姓名、账号或人员标识"/></label><label className="field"><span>动作</span><input value={draft.action} onChange={(event)=>update("action",event.target.value)} placeholder="如 performance.order_posted"/></label><label className="field"><span>实体类型</span><input value={draft.entityType} onChange={(event)=>update("entityType",event.target.value)} placeholder="如 performance_order"/></label><label className="field"><span>实体标识</span><input value={draft.entityId} onChange={(event)=>update("entityId",event.target.value)} placeholder="稳定标识"/></label><label className="field"><span>开始时间</span><input type="datetime-local" value={draft.from} onChange={(event)=>update("from",event.target.value)}/></label><label className="field"><span>结束时间</span><input type="datetime-local" value={draft.to} onChange={(event)=>update("to",event.target.value)}/></label></div><div className="order-filter-actions"><button type="button" onClick={clear}>清除条件</button><button type="submit">查询审计</button></div></form>{error?<div className="query-feedback"><p className="page-message" role="alert">{error}</p><button type="button" onClick={()=>setRevision((value)=>value+1)}>重试查询</button></div>:null}<div className="orders-table-wrap"><table className="audit-table"><thead><tr><th>时间</th><th>人员</th><th>动作</th><th>实体</th><th>变更前</th><th>变更后</th></tr></thead><tbody>{!loading&&!error&&audits.length===0?<tr><td className="empty-cell" colSpan={6}>没有符合当前权限和条件的审计记录。</td></tr>:audits.map((row)=><tr key={row.id}><td><time dateTime={row.createdAt}>{auditDateTime(row.createdAt)}</time></td><td>{row.actorDisplayName??"系统"}<small className="table-secondary">{row.actorUsername??row.actorPersonId??"—"}</small></td><td>{row.action}</td><td>{row.entityType}<small className="table-secondary">{row.entityId??"—"}</small></td><td className="audit-data"><code>{auditData(row.beforeData)}</code></td><td className="audit-data"><code>{auditData(row.afterData)}</code></td></tr>)}</tbody></table></div><nav className="table-pagination" aria-label="审计分页"><span>按不可变审计编号倒序加载</span>{nextCursor?<button type="button" disabled={loading} onClick={()=>setCursor(nextCursor)}>{loading?"正在加载…":"加载更多"}</button>:null}</nav></section></main>;
 }
 
 function AccountsPage({user}:{user:User}){

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -334,6 +334,9 @@ th { color: #68778a; background: #fafbfc; font-weight: 600; }
 .account-search .account-search-clear:hover { color: var(--navy); background: #eef2f6; }
 .icon-action { width: 36px; height: 36px; border: 1px solid var(--line); border-radius: 6px; color: #56657a; background: #fff; display: grid; place-items: center; cursor: pointer; }
 .orders-table-wrap { overflow-x: auto; }
+.audit-table { min-width: 1180px; }
+.audit-data { min-width: 220px; max-width: 340px; white-space: normal; }
+.audit-data code { color: #3f5065; font-family: Consolas, monospace; overflow-wrap: anywhere; }
 .permission-matrix-table { min-width: 1080px; white-space: normal; }
 .permission-matrix-table th, .permission-matrix-table td { vertical-align: top; line-height: 1.65; }
 .permission-matrix-table td:first-child { min-width: 112px; color: var(--navy); }


### PR DESCRIPTION
Closes #53

## 实现
- 新增只读分域审计查询 API，支持人员、动作、实体、时间和稳定游标过滤
- 管理域与业务域按角色取并集，订单/事件与目标审计按稳定历史范围授权
- 递归移除凭据字段，且不返回 IP、密码、临时密码或令牌
- 新增 Web 审计查询页，固定 Asia/Shanghai 时区且无修改/删除入口

## 验证
- API 全量测试：144/144
- Web Playwright：21/21
- API/Web 类型检查与生产构建通过
- npm audit --omit=dev：0 vulnerabilities
- docker compose --env-file .env.example config --quiet：通过
- frontend-design-premium strict：0 findings
- 规格复核与 Standards 复核：CLEAN