### PR TITLE
feat: add stable page routes (#54)

### DIFF
--- a/apps/api/src/ledger-governance.integration.test.ts
+++ b/apps/api/src/ledger-governance.integration.test.ts
@@ -284,7 +284,7 @@ test("更正申请被拒绝、撤销或批准超过二十四小时后均不能�
     let now=new Date("2026-09-10T01:02:03.000Z");
     await withTestApi(database.url,async(app)=>{
       const assistant=await writeHeaders(app,"ledger_assistant");
-      const leader=await writeHeaders(app,"ledger_assistant_leader");
+      let leader=await writeHeaders(app,"ledger_assistant_leader");
       const hr=await writeHeaders(app,"ledger_hr");
       const create=async(orderNo:string)=>{
         const response=await app.inject({method:"POST",url:"/api/performance/orders",headers:assistant,payload:{orderNo,customerName:"更正治理客户",customerUnit:"测试单位",businessRegionSourceText:"江苏原文",businessRegionCode:"CN-JS",salespersonPersonId:Number(scenario.memberPersonId),sourceReceivedOn:"2026-08-15",amount:100,reason:"八月入账"}});
@@ -314,6 +314,7 @@ test("更正申请被拒绝、撤销或批准超过二十四小时后均不能�
       const expiredId=await request(expiredOrder,"批准后过期");
       assert.equal((await app.inject({method:"POST",url:`/api/accounting-corrections/${expiredId}/approve`,headers:hr,payload:{note:"批准"}})).statusCode,200);
       now=new Date(now.getTime()+24*60*60*1000+1);
+      leader=await writeHeaders(app,"ledger_assistant_leader");
       const expired=await execute(expiredOrder,expiredId,"expired-event");
       assert.equal(expired.statusCode,409,expired.body);
       assert.match(expired.body,/已过期/);

--- a/apps/api/src/modules/auth.ts
+++ b/apps/api/src/modules/auth.ts
@@ -119,6 +119,7 @@ export async function registerAuth(app: FastifyInstance, db: Database, clock: ()
   app.addHook("preHandler", async (request, reply) => {
     const token = request.cookies[SESSION_COOKIE];
     if (!token) return;
+    const now = clock();
     const result = await db.query<{
       id: string;
       person_id: string;
@@ -137,10 +138,10 @@ export async function registerAuth(app: FastifyInstance, db: Database, clock: ()
        join users u on u.id = s.user_id and u.is_active
        join people p on p.user_id=u.id
        left join user_roles ur on ur.user_id = u.id
-       where s.token_hash = $1 and s.revoked_at is null and s.expires_at > now()
-         and s.last_seen_at > now() - interval '30 minutes'
+       where s.token_hash = $1 and s.revoked_at is null and s.expires_at > $2
+         and s.last_seen_at > $2 - interval '30 minutes'
        group by u.id, p.id, u.username, u.display_name, u.must_change_password, s.id, s.last_seen_at, s.csrf_token_hash`,
-      [hashSessionToken(token)],
+      [hashSessionToken(token), now],
     );
     const row = result.rows[0];
     if (!row) return;
@@ -184,8 +185,8 @@ export async function registerAuth(app: FastifyInstance, db: Database, clock: ()
         return reply.code(403).send({ code: "ORIGIN_INVALID", message: "请求来源不受信任" });
       }
     }
-    if (row.last_seen_at.getTime() <= Date.now() - 5 * 60 * 1000) {
-      await db.query("update sessions set last_seen_at=now() where id=$1", [row.session_id]);
+    if (row.last_seen_at.getTime() <= now.getTime() - 5 * 60 * 1000) {
+      await db.query("update sessions set last_seen_at=$2 where id=$1", [row.session_id, now]);
     }
   });
 
@@ -245,9 +246,9 @@ export async function registerAuth(app: FastifyInstance, db: Database, clock: ()
     try {
       await client.query("begin");
       await client.query(
-        `insert into sessions (user_id, token_hash, csrf_token_hash, expires_at, user_agent, ip_address)
-         values ($1, $2, $3, $4, $5, $6)`,
-        [user.id, tokenHash, csrf.tokenHash, new Date(now.getTime() + SESSION_TTL_MS), request.headers["user-agent"] ?? null, request.ip],
+        `insert into sessions (user_id, token_hash, csrf_token_hash, expires_at, created_at, last_seen_at, user_agent, ip_address)
+         values ($1, $2, $3, $4, $5, $5, $6, $7)`,
+        [user.id, tokenHash, csrf.tokenHash, new Date(now.getTime() + SESSION_TTL_MS), now, request.headers["user-agent"] ?? null, request.ip],
       );
       await client.query("delete from auth_login_throttles where scope='account' and throttle_key=$1", [accountKey]);
       await client.query(

--- a/apps/web/e2e/analysis.spec.ts
+++ b/apps/web/e2e/analysis.spec.ts
@@ -6,7 +6,7 @@ const { Client } = pg;
 
 test.use({ locale: "zh-CN", timezoneId: "Asia/Shanghai", viewport: { width: 1280, height: 800 } });
 
-test("桌面总览显示事件快照地区、外贸、客户单位和待补齐对账", async ({ database, page }) => {
+test("业绩分析页显示事件快照地区、外贸、客户单位和待补齐对账", async ({ database, page }) => {
   const userId = await seedTestUser(database.url, {
     username: "e2e_analysis_assistant",
     displayName: "E2E 分析助理",
@@ -73,6 +73,7 @@ test("桌面总览显示事件快照地区、外贸、客户单位和待补齐�
   await page.getByLabel("账号").fill("e2e_analysis_assistant");
   await page.getByLabel("密码", { exact: true }).fill("Analysis@123");
   await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+  await page.getByRole("button", { name: "业绩分析" }).click();
 
   const analysis = page.getByRole("region", { name: "地区与客户单位分析" });
   await analysis.getByLabel("分析月份").fill("2026-08");

--- a/apps/web/e2e/audits.spec.ts
+++ b/apps/web/e2e/audits.spec.ts
@@ -27,8 +27,8 @@ test("审计页面只读展示所属域并支持组合过滤", async ({ database
       [actor.rows[0]!.id],
     );
     await setup.query(
-      `insert into performance_events(order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,department_name,group_name)
-       values($1,'initial',100,100,100,date_trunc('month',current_date)::date,current_date,'E2E 审计事件',$2,'E2E 审计业务员','E2E 部门','E2E 小组')`,
+      `insert into performance_events(order_id,event_type,delta_amount,resulting_current_revenue,resulting_counted_amount,accounting_month,occurred_on,reason,salesperson_person_id,salesperson_name,department_name,group_name,created_at)
+       values($1,'initial',100,100,100,date_trunc('month',current_date)::date,current_date,'E2E 审计事件',$2,'E2E 审计业务员','E2E 部门','E2E 小组','2026-09-01T12:30:30Z')`,
       [order.rows[0]!.id, actor.rows[0]!.id],
     );
     await setup.query(

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -383,7 +383,7 @@ test("无业务权限账号访问订单深链时看到明确权限说明", async
   await page.getByLabel("密码", { exact: true }).fill("Forbidden@123");
   await page.getByRole("button", { name: "进入 SampleFlow" }).click();
   await expect(page.getByRole("heading", { name: "无法访问订单业绩" })).toBeVisible();
-  await expect(page.getByText("当前账号没有订单查看权限。", { exact: true })).toBeVisible();
+  await expect(page.getByText("403 · 当前账号没有订单业绩权限。", { exact: true })).toBeVisible();
   await expect(page).toHaveURL(/page=orders/);
 });
 

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -1,0 +1,99 @@
+import pg from "pg";
+import { seedTestUser } from "../../api/src/test-support/fixtures.js";
+import { expect, test } from "./full-stack.js";
+
+const { Client } = pg;
+
+async function login(page: import("@playwright/test").Page, username: string) {
+  await page.getByLabel("账号").fill(username);
+  await page.getByLabel("密码", { exact: true }).fill("Routes@123");
+  await page.getByRole("button", { name: "进入 SampleFlow" }).click();
+}
+
+test("八个主要页面使用稳定 URL、标题并支持刷新和浏览器历史", async ({ database, page }) => {
+  const userId = await seedTestUser(database.url, {
+    username: "e2e_routes_all",
+    displayName: "E2E 路由全权限",
+    password: "Routes@123",
+    roleCode: "system_admin",
+    roleName: "系统管理员",
+  });
+  await seedTestUser(database.url, {
+    username: "e2e_routes_hr_seed",
+    displayName: "E2E 路由人事角色种子",
+    password: "Routes@123",
+    roleCode: "hr",
+    roleName: "人事部",
+  });
+  const client = new Client({ connectionString: database.url });
+  await client.connect();
+  try {
+    await client.query("insert into user_roles(user_id,role_code) values($1,'hr')", [userId]);
+  } finally {
+    await client.end();
+  }
+
+  await page.goto("/?page=overview");
+  await login(page, "e2e_routes_all");
+
+  const routes = [
+    { id: "overview", nav: "业绩总览", heading: "业绩账本总览", title: "业绩总览 — SampleFlow" },
+    { id: "orders", nav: "订单业绩", heading: "订单业绩", title: "订单业绩 — SampleFlow" },
+    { id: "goals", nav: "目标管理", heading: "目标管理", title: "目标管理 — SampleFlow" },
+    { id: "organization", nav: "组织架构", heading: "组织架构", title: "组织架构 — SampleFlow" },
+    { id: "approvals", nav: "审批中心", heading: "审批中心", title: "审批中心 — SampleFlow" },
+    { id: "accounts", nav: "账号管理", heading: "账号管理", title: "账号管理 — SampleFlow" },
+    { id: "analysis", nav: "业绩分析", heading: "地区与客户单位分析", title: "业绩分析 — SampleFlow" },
+    { id: "audits", nav: "审计查询", heading: "审计查询", title: "审计查询 — SampleFlow" },
+  ] as const;
+
+  for (const route of routes) {
+    if (route.id !== "overview") await page.getByRole("button", { name: route.nav }).click();
+    await expect(page).toHaveURL(new RegExp(`[?&]page=${route.id}(?:&|$)`));
+    await expect(page.getByRole("heading", { name: route.heading, exact: true })).toBeVisible();
+    await expect(page).toHaveTitle(route.title);
+  }
+
+  await page.goBack();
+  await expect(page).toHaveURL(/[?&]page=analysis(?:&|$)/);
+  await expect(page.getByRole("heading", { name: "地区与客户单位分析", exact: true })).toBeVisible();
+  await page.goForward();
+  await expect(page.getByRole("heading", { name: "审计查询", exact: true })).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole("heading", { name: "审计查询", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "账号管理" }).click();
+  await page.getByLabel("搜索账号").fill("e2e_routes");
+  await page.getByRole("button", { name: "搜索账号" }).click();
+  await expect(page).toHaveURL(/accountSearch=e2e_routes/);
+  await page.getByRole("button", { name: "账号管理" }).click();
+  await expect(page).toHaveURL(/accountSearch=e2e_routes/);
+  await page.getByRole("button", { name: "审计查询" }).click();
+  await page.goBack();
+  await expect(page.getByLabel("搜索账号")).toHaveValue("e2e_routes");
+
+  await page.goto("/?page=accounts");
+  await page.evaluate(()=>window.history.pushState({},"","/?page=toString"));
+  await page.goBack();
+  await page.goForward();
+  await expect(page).toHaveURL(/[?&]page=accounts(?:&|$)/);
+  await expect(page.getByRole("heading", { name: "账号管理", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: "退出登录" }).click();
+  await expect(page.getByRole("heading", { name: "登录系统", exact: true })).toBeVisible();
+  await expect(page).toHaveTitle("登录 — SampleFlow");
+});
+
+test("无权限业务路由显示明确 403 而不是其他页面或空数据", async ({ database, page }) => {
+  await seedTestUser(database.url, {
+    username: "e2e_routes_admin",
+    displayName: "E2E 路由管理员",
+    password: "Routes@123",
+    roleCode: "system_admin",
+    roleName: "系统管理员",
+  });
+  await page.goto("/?page=analysis");
+  await login(page, "e2e_routes_admin");
+  await expect(page.getByRole("heading", { name: "无法访问业绩分析" })).toBeVisible();
+  await expect(page.getByText("403 · 当前账号没有业绩分析权限。", { exact: true })).toBeVisible();
+  await expect(page).toHaveTitle("业绩分析 — SampleFlow");
+  await expect(page.getByText("本月没有已映射省份事件。", { exact: true })).toHaveCount(0);
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { FormEvent, type ReactNode, useCallback, useEffect, useId, useRef, useSt
 import { createPortal } from "react-dom";
 import { Activity, BarChart3, ChevronRight, ClipboardCheck, Database, Eye, EyeOff, FileClock, FileUp, LogOut, Network, PauseCircle, PlayCircle, Plus, RefreshCw, Search, ShieldCheck, Target, UsersRound, X } from "lucide-react";
 import type { ChinaMap } from "./china-map";
+import { PAGE_ORDER, PAGE_ROUTES, readPageId, type PageId } from "./page-routes";
 
 type Capabilities = { viewPerformance:boolean; viewGoals:boolean; viewAudits:boolean; viewOrganization:boolean; viewApprovals:boolean; editPerformance:boolean; exportPerformance:boolean; exportGoals:boolean; manageAccounts:boolean; manageOrganization:boolean };
 type User = { id: string; personId:string; username: string; displayName: string; mustChangePassword: boolean; roles: string[]; capabilities:Capabilities };
@@ -123,6 +124,7 @@ function Login({ onLogin }: { onLogin: (user: User) => void }) {
   const [username, setUsername] = useState(import.meta.env.DEV ? "sales_assistant" : "");
   const [password, setPassword] = useState(import.meta.env.DEV ? "SampleFlow@2026" : "");
   const [message, setMessage] = useState("");
+  useEffect(()=>{document.title="登录 — SampleFlow";},[]);
   const [submitting, setSubmitting] = useState(false);
   const [readiness, setReadiness] = useState<"checking" | "ready" | "unavailable">("checking");
   useEffect(() => {
@@ -165,25 +167,17 @@ function Login({ onLogin }: { onLogin: (user: User) => void }) {
 }
 
 function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
-  type PageId = "overview"|"goals"|"orders"|"organization"|"approvals"|"accounts"|"audits";
-  const pages = [
-    user.capabilities.viewPerformance ? {id:"overview" as const,Icon:BarChart3,label:"业绩总览"} : null,
-    user.capabilities.viewGoals ? {id:"goals" as const,Icon:Target,label:"目标管理"} : null,
-    user.capabilities.viewPerformance ? {id:"orders" as const,Icon:ClipboardCheck,label:"订单业绩"} : null,
-    user.capabilities.viewOrganization ? {id:"organization" as const,Icon:Network,label:"组织架构"} : null,
-    user.capabilities.viewApprovals ? {id:"approvals" as const,Icon:FileClock,label:"审批中心"} : null,
-    user.capabilities.viewAudits ? {id:"audits" as const,Icon:Search,label:"审计查询"} : null,
-    user.capabilities.manageAccounts ? {id:"accounts" as const,Icon:UsersRound,label:"账号管理"} : null,
-  ].filter((page):page is NonNullable<typeof page>=>page!==null);
+  const pageIcons = {overview:BarChart3,goals:Target,orders:ClipboardCheck,analysis:Activity,organization:Network,approvals:FileClock,audits:Search,accounts:UsersRound};
+  const canOpen=(page:PageId)=>user.capabilities[PAGE_ROUTES[page].capability];
+  const pages=PAGE_ORDER.filter(canOpen).map((id)=>({id,Icon:pageIcons[id],label:PAGE_ROUTES[id].label}));
   const defaultPage:PageId=user.capabilities.manageAccounts?"accounts":pages[0]?.id??"overview";
-  const canOpenOrders=pages.some((page)=>page.id==="orders");
-  const requestedPage=new URLSearchParams(window.location.search).get("page");
-  const [active, setActive] = useState<PageId|"forbidden">(requestedPage==="orders"?(canOpenOrders?"orders":"forbidden"):defaultPage);
-  const navigate=useCallback((page:PageId)=>{const params=new URLSearchParams(window.location.search);if(page==="orders")params.set("page","orders");else params.delete("page");window.history.pushState({},"",`${window.location.pathname}${params.size?`?${params.toString()}`:""}${window.location.hash}`);setActive(page);},[]);
-  useEffect(()=>{const restore=()=>{const page=new URLSearchParams(window.location.search).get("page");setActive(page==="orders"?(canOpenOrders?"orders":"forbidden"):defaultPage);};window.addEventListener("popstate",restore);return()=>window.removeEventListener("popstate",restore);},[canOpenOrders,defaultPage]);
+  const [active,setActive]=useState<PageId>(()=>readPageId(window.location.search)??defaultPage);
+  const navigate=useCallback((page:PageId,mode:"push"|"replace"="push")=>{if(mode==="push"&&readPageId(window.location.search)===page)return;const params=new URLSearchParams(window.location.search);params.set("page",page);window.history[`${mode}State`]({},"",`${window.location.pathname}?${params.toString()}${window.location.hash}`);setActive(page);},[]);
+  useEffect(()=>{if(!readPageId(window.location.search))navigate(defaultPage,"replace");const restore=()=>{const page=readPageId(window.location.search);if(page)setActive(page);else navigate(defaultPage,"replace");};window.addEventListener("popstate",restore);return()=>window.removeEventListener("popstate",restore);},[defaultPage,navigate]);
+  useEffect(()=>{document.title=`${PAGE_ROUTES[active].label} — SampleFlow`;},[active]);
   async function logout() { await apiFetch("/api/auth/logout", { method: "POST" }); onLogout(); }
-  const content = active === "forbidden"
-    ? <main className="dashboard"><header><div><h1>无法访问订单业绩</h1><p>该页面需要业务查看权限</p></div></header><div className="permission-note"><ShieldCheck size={18}/>当前账号没有订单查看权限。</div></main>
+  const content = !canOpen(active)
+    ? <main className="dashboard"><header><div><h1>无法访问{PAGE_ROUTES[active].label}</h1><p>该页面不在当前账号的角色权限范围内</p></div></header><div className="permission-note"><ShieldCheck size={18}/>403 · 当前账号没有{PAGE_ROUTES[active].label}权限。</div></main>
     : active === "orders"
     ? <OrdersPage user={user} />
     : active === "goals"
@@ -192,6 +186,8 @@ function Dashboard({ user, onLogout }: { user: User; onLogout: () => void }) {
         ? <GoalsPage user={user} pendingOnly />
       : active === "organization"
         ? <OrganizationPage user={user}/>
+      : active === "analysis"
+        ? <AnalysisPage/>
       : active === "audits"
         ? <AuditPage/>
       : active === "accounts"
@@ -373,13 +369,12 @@ function Overview({ canEdit, canExport, onEnterOrders }: { canEdit: boolean; can
         onClose={()=>{groupDetailsRequest.current+=1;setSelectedGroup(null);}}
       >{groupDetailsError?<p className="form-error group-drilldown" role="alert">{groupDetailsError}</p>:groupDetails?<div className="group-drilldown"><AchievementMembers members={groupDetails.members}/></div>:<p className="group-drilldown">正在读取小组业绩构成…</p>}</Modal>:null}
       <section className="metric-band"><Metric label="账本净额" value={data ? formatMoney(data.metrics.total) : "—"} note={`${data?.metrics.eventCount ?? 0} 条授权范围事件`}/><Metric label="正式报表" value="从生效目标进入" note="未生效不计算达成率"/><Metric label="待处理审批" value={String(data?.metrics.pendingApprovals ?? 0)} note="目标确认与变更" warning/><Metric label="负向调整" value={data ? formatMoney(data.metrics.negativeTotal) : "—"} note="暂停与金额变更" negative/></section>
-      <AnalysisPanel/>
       <section className="dashboard-grid"><article className="trend-panel"><PanelTitle title="月度业绩趋势" note={`${data?.month.slice(0,4)??"当前"} 年授权范围业绩净额`}/><TrendChart year={data?.month.slice(0,4)??""} monthly={data?.monthly??[]}/></article><article className="ranking-panel"><PanelTitle title="小组业绩" note="按事件发生时组织归属"/>{data?.groups.map((group,i) => <div className="rank-row" key={group.id}><span>{i+1}</span><div><strong>{group.name}</strong><span><i style={{width:`${Math.max(0, Number(group.total)) / maxGroup * 100}%`}}/></span></div><b>{(Number(group.total)/10000).toFixed(1)}万</b></div>)}</article></section>
       <section className="events-panel"><div className="panel-title"><div><h2>最近业绩事件</h2><p>入账后不可覆盖或删除</p></div><button onClick={onEnterOrders}>查看全部</button></div><table><thead><tr><th>订单编号</th><th>业务员</th><th>事件类型</th><th>记账月</th><th>金额</th><th>组织归属</th><th>状态</th></tr></thead><tbody>{data?.recent.map((event) => <tr key={`${event.orderNo}-${event.month}-${event.amount}`}><td>{event.orderNo}</td><td>{event.salespersonName}</td><td>{eventTypeName(event.eventType)}</td><td>{event.month}</td><td className={Number(event.amount)<0?"negative":""}>{formatMoney(event.amount)}</td><td>{event.groupName}</td><td>已入账</td></tr>)}</tbody></table></section>
     </main>;
 }
 
-function AnalysisPanel(){
+function AnalysisPage(){
   const[month,setMonth]=useState(businessDateToday().slice(0,7));
   const[data,setData]=useState<PerformanceAnalysis|null>(null);
   const[error,setError]=useState("");
@@ -387,11 +382,11 @@ function AnalysisPanel(){
   const[selectedProvince,setSelectedProvince]=useState<AnalysisProvince|null>(null);
   useEffect(()=>setSelectedProvince(null),[month]);
   useEffect(()=>{const controller=new AbortController();setData(null);setError("");fetch(`/api/performance/analysis?month=${month}`,{signal:controller.signal}).then(async(response)=>{const result=await readResponseJson<PerformanceAnalysis&{message?:string}>(response,"分析服务响应无效");if(!response.ok)throw new Error(result.message??"分析加载失败");setData(result);}).catch((failure)=>{if(failure instanceof DOMException&&failure.name==="AbortError")return;setError(failure instanceof Error?failure.message:"分析加载失败");});return()=>controller.abort();},[month,revision]);
-  return <section className="analysis-panel" aria-labelledby="analysis-title"><div className="analysis-header"><div><h2 id="analysis-title">地区与客户单位分析</h2><p>只按事件发生时的不可变分析维度快照汇总，不使用订单当前资料</p></div><label><span>分析月份</span><input type="month" value={month} onChange={(event)=>setMonth(event.target.value)}/></label></div>
+  return <main className="dashboard analysis-page"><section className="analysis-panel" aria-labelledby="analysis-title"><div className="analysis-header"><div><h1 id="analysis-title">地区与客户单位分析</h1><p>只按事件发生时的不可变分析维度快照汇总，不使用订单当前资料</p></div><label><span>分析月份</span><input type="month" value={month} onChange={(event)=>setMonth(event.target.value)}/></label></div>
     {error?<div className="query-feedback"><p className="page-message" role="alert">{error}</p><button type="button" onClick={()=>setRevision((value)=>value+1)}>重试查询</button></div>:null}
     {!data&&!error?<p className="analysis-loading" role="status">正在读取地区与客户单位分析…</p>:null}
     {data?<><section className="metric-band analysis-metrics"><Metric label="授权范围总账" value={formatMoney(data.ledger.totalAmount)} note={`${data.ledger.eventCount} 条事件`}/><Metric label="已映射" value={formatMoney(data.mapped.totalAmount)} note={`${data.mapped.eventCount} 条可信维度事件`}/><Metric label="待补齐" value={formatMoney(data.pending.totalAmount)} note={`${data.pending.eventCount} 条缺少可信维度事件`} warning/></section><p className={`analysis-reconciliation ${data.reconciled?"":"analysis-reconciliation-error"}`}>{data.reconciled?"已映射金额 + 待补齐金额与授权范围总账完全对平。":"分析维度对账失败，请停止使用当前汇总。"}</p><div className="analysis-map-layout"><ChinaProvinceMap provinces={data.provinces} selectedRegionCode={selectedProvince?.regionCode??null} onSelect={setSelectedProvince}/><article className="analysis-card analysis-province-ranking"><h3>省份汇总</h3><div className="orders-table-wrap"><table aria-label="省份汇总"><thead><tr><th>省份</th><th>事件</th><th>金额</th></tr></thead><tbody>{data.provinces.length?data.provinces.map((item)=><tr key={item.regionCode}><td><button type="button" className="analysis-link" aria-pressed={selectedProvince?.regionCode===item.regionCode} onClick={()=>setSelectedProvince(item)}>{item.regionName}</button></td><td>{item.eventCount}</td><td className={Number(item.totalAmount)<0?"negative":""}>{formatMoney(item.totalAmount)}</td></tr>):<tr><td colSpan={3} className="empty-cell">本月没有已映射省份事件。</td></tr>}</tbody></table></div><div className="analysis-foreign"><div><strong>外贸（EXT-TRADE）</strong><span>独立区域，不进入省份统计</span></div><b className={Number(data.foreignTrade.totalAmount)<0?"negative":""}>{data.foreignTrade.eventCount} 条事件 · {formatMoney(data.foreignTrade.totalAmount)}</b></div></article></div><article className="analysis-card analysis-customer-summary"><h3>客户单位汇总</h3><div className="orders-table-wrap"><table aria-label="客户单位汇总"><thead><tr><th>区域</th><th>客户单位</th><th>事件</th><th>金额</th></tr></thead><tbody>{data.customers.length?data.customers.map((item)=><tr key={`${item.regionCode}:${item.customerUnit}`}><td>{item.regionName}</td><td>{item.customerUnit}</td><td>{item.eventCount}</td><td className={Number(item.totalAmount)<0?"negative":""}>{formatMoney(item.totalAmount)}</td></tr>):<tr><td colSpan={4} className="empty-cell">本月没有已映射客户单位事件。</td></tr>}</tbody></table></div></article>{selectedProvince?<AnalysisDrilldown key={`${month}:${selectedProvince.regionCode}`} province={selectedProvince} month={month}/>:null}</>:null}
-  </section>;
+  </section></main>;
 }
 
 function ChinaProvinceMap({provinces,selectedRegionCode,onSelect}:{provinces:AnalysisProvince[];selectedRegionCode:string|null;onSelect:(province:AnalysisProvince)=>void}){

--- a/apps/web/src/page-routes.ts
+++ b/apps/web/src/page-routes.ts
@@ -1,0 +1,18 @@
+export const PAGE_ROUTES = {
+  overview: { label: "业绩总览", capability: "viewPerformance" },
+  goals: { label: "目标管理", capability: "viewGoals" },
+  orders: { label: "订单业绩", capability: "viewPerformance" },
+  analysis: { label: "业绩分析", capability: "viewPerformance" },
+  organization: { label: "组织架构", capability: "viewOrganization" },
+  approvals: { label: "审批中心", capability: "viewApprovals" },
+  audits: { label: "审计查询", capability: "viewAudits" },
+  accounts: { label: "账号管理", capability: "manageAccounts" },
+} as const;
+
+export type PageId = keyof typeof PAGE_ROUTES;
+export const PAGE_ORDER = Object.keys(PAGE_ROUTES) as PageId[];
+
+export function readPageId(search: string): PageId | null {
+  const page = new URLSearchParams(search).get("page");
+  return page && Object.hasOwn(PAGE_ROUTES, page) ? page as PageId : null;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -253,8 +253,10 @@ form button:disabled { cursor: wait; opacity: .72; }
 .events-panel .panel-title { padding: 20px 22px 15px; }
 .events-panel .panel-title button { border: 0; color: var(--blue); background: transparent; cursor: pointer; }
 .analysis-panel { margin-top: 20px; border: 1px solid var(--line); background: #fff; }
+.analysis-page .analysis-panel { margin-top: 0; }
 .analysis-header { min-height: 78px; padding: 16px 22px; display: flex; align-items: center; justify-content: space-between; gap: 20px; }
-.analysis-header h2, .analysis-card h3 { margin: 0; font-size: 16px; }
+.analysis-header h1 { margin: 0; font-size: 22px; }
+.analysis-card h3 { margin: 0; font-size: 16px; }
 .analysis-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; }
 .analysis-header label { width: 180px; margin: 0; }
 .analysis-header label span { display: block; margin-bottom: 6px; color: var(--muted); font-size: 12px; }


### PR DESCRIPTION
## 变更
- 为 8 个主要 Web 页面提供稳定 ?page= URL、标题、刷新与浏览器历史恢复
- 将业绩分析从总览拆为独立页面，保留原有服务端业务规则和查询行为
- 未授权深链显示明确 403，并保留已有筛选查询参数
- 统一认证会话的注入时钟，消除固定业务日期测试随现实时间失效的问题

## 验证
- API：144/144
- Web：23/23
- 生产构建通过
- 
pm audit --omit=dev：0 vulnerabilities
- Compose 配置校验通过
- 前端严格审计：0 findings
- Spec/Standards review：CLEAN

Closes #54