### PR TITLE
[P1][TB-25] 备份并恢复到新数据库

### DIFF
--- a/apps/api/src/backup-restore.integration.test.ts
+++ b/apps/api/src/backup-restore.integration.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import { appendFile, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import pg from "pg";
+import { seedTestUser } from "./test-support/fixtures.js";
+import { withTestApi } from "./test-support/test-api.js";
+import { withMigratedTestDatabase } from "./test-support/test-database.js";
+
+const { Client } = pg;
+const execFileAsync = promisify(execFile);
+const apiRoot = fileURLToPath(new URL("../", import.meta.url));
+const operationDirectory = fileURLToPath(new URL("../../../scripts/", import.meta.url));
+
+type DatabaseRoles = Readonly<{
+  migration: string;
+  app: string;
+  backup: string;
+  migrationPassword: string;
+  appPassword: string;
+  backupPassword: string;
+}>;
+
+function rolesFor(databaseName: string): DatabaseRoles {
+  const suffix = databaseName.slice("sampleflow_test_".length);
+  return {
+    migration: `sf_migration_${suffix}`,
+    app: `sf_app_${suffix}`,
+    backup: `sf_backup_${suffix}`,
+    migrationPassword: "isolated-migration-'test\\2026",
+    appPassword: "isolated-app-'test\\password-2026",
+    backupPassword: "isolated-backup-'test\\2026",
+  };
+}
+
+function roleUrl(databaseUrl: string, role: string, password: string): string {
+  const url = new URL(databaseUrl);
+  url.username = role;
+  url.password = password;
+  return url.toString();
+}
+
+async function provision(databaseUrl: string, roles: DatabaseRoles): Promise<void> {
+  await execFileAsync(process.execPath, ["--import", "tsx", "src/cli/provision-database-roles.ts"], {
+    cwd: apiRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NODE_ENV: "test",
+      DATABASE_ADMIN_URL: databaseUrl,
+      DB_MIGRATION_USER: roles.migration,
+      DB_MIGRATION_PASSWORD: roles.migrationPassword,
+      DB_APP_USER: roles.app,
+      DB_APP_PASSWORD: roles.appPassword,
+      DB_BACKUP_USER: roles.backup,
+      DB_BACKUP_PASSWORD: roles.backupPassword,
+    },
+  });
+}
+
+async function dropRoles(adminUrl: string, roles: DatabaseRoles): Promise<void> {
+  const admin = new Client({ connectionString: adminUrl });
+  await admin.connect();
+  try {
+    await admin.query(`drop role if exists ${roles.app},${roles.backup},${roles.migration}`);
+  } finally {
+    await admin.end();
+  }
+}
+
+async function runOperation(command: string, variables: Readonly<Record<string, string>>, backupDirectory: string) {
+  const environment = Object.entries(variables).flatMap(([name, value]) => ["-e", `${name}=${value}`]);
+  return execFileAsync("docker", [
+    "run", "--rm", "--add-host", "host.docker.internal:host-gateway",
+    ...environment,
+    "-v", `${operationDirectory}:/operations:ro`,
+    "-v", `${backupDirectory}:/backup`,
+    "postgres:16", "bash", "/operations/database-operations.sh", command,
+  ], { encoding: "utf8", timeout: 60_000 });
+}
+
+test("自定义格式备份只恢复到显式新库且保持来源与恢复摘要一致", async () => {
+  let roleCleanup: { adminUrl: string; roles: DatabaseRoles } | undefined;
+  try {
+    await withMigratedTestDatabase(async (source) => {
+    await seedTestUser(source.url, {
+      username: "restore_smoke",
+      displayName: "恢复验收",
+      password: "Restore@123",
+      roleCode: "sales_assistant",
+      roleName: "销售助理",
+    });
+    const roles = rolesFor(source.name);
+    roleCleanup = { adminUrl: source.adminUrl, roles };
+    await provision(source.url, roles);
+
+    const sourceUrl = new URL(source.url);
+    const adminUrl = new URL(source.adminUrl);
+    const targetName = `sampleflow_test_${randomUUID().replaceAll("-", "")}`;
+    const corruptTargetName = `sampleflow_test_${randomUUID().replaceAll("-", "")}`;
+    const targetUrl = new URL(sourceUrl);
+    targetUrl.pathname = `/${targetName}`;
+    const backupDirectory = await mkdtemp(path.join(tmpdir(), "sampleflow-backup-"));
+    const sourceVariables = {
+      SOURCE_DB_HOST: "host.docker.internal",
+      SOURCE_DB_PORT: sourceUrl.port,
+      SOURCE_DB_NAME: decodeURIComponent(sourceUrl.pathname.slice(1)),
+      SOURCE_DB_USER: roles.backup,
+      SOURCE_DB_PASSWORD: roles.backupPassword,
+      BACKUP_FILE: "/backup/sampleflow.dump",
+    };
+    const restoreVariables = {
+      ...sourceVariables,
+      TARGET_DB_HOST: "host.docker.internal",
+      TARGET_DB_PORT: adminUrl.port,
+      TARGET_DB_ADMIN_NAME: decodeURIComponent(adminUrl.pathname.slice(1)),
+      TARGET_DB_ADMIN_USER: decodeURIComponent(adminUrl.username),
+      TARGET_DB_ADMIN_PASSWORD: decodeURIComponent(adminUrl.password),
+      TARGET_DB_NAME: targetName,
+      TARGET_DB_OWNER: roles.migration,
+      TARGET_DB_OWNER_PASSWORD: roles.migrationPassword,
+      TARGET_DB_APP_USER: roles.app,
+      TARGET_DB_BACKUP_USER: roles.backup,
+    };
+
+    try {
+      const concurrentBackups = await Promise.allSettled([
+        runOperation("backup", sourceVariables, backupDirectory),
+        runOperation("backup", sourceVariables, backupDirectory),
+      ]);
+      assert.equal(
+        concurrentBackups.filter((result) => result.status === "fulfilled").length,
+        1,
+        concurrentBackups.map((result) => result.status === "fulfilled" ? result.value.stdout : result.reason.stderr).join("\n"),
+      );
+      const rejectedBackup = concurrentBackups.find((result) => result.status === "rejected");
+      assert.match(String((rejectedBackup as PromiseRejectedResult).reason.stderr), /已存在或正在由其他进程写入|拒绝覆盖已有文件/);
+      const backup = await readFile(path.join(backupDirectory, "sampleflow.dump"));
+      assert.equal(backup.subarray(0, 5).toString("ascii"), "PGDMP");
+      assert.match(await readFile(path.join(backupDirectory, "sampleflow.dump.sha256"), "utf8"), /^[a-f0-9]{64}  sampleflow\.dump\r?\n$/);
+      const backupNames = ["sampleflow.dump", "sampleflow.dump.sha256", "sampleflow.dump.summary", "sampleflow.dump.summary.sha256"];
+      const completedBackup = await Promise.all(backupNames.map((name) => readFile(path.join(backupDirectory, name))));
+      await assert.rejects(runOperation("backup", sourceVariables, backupDirectory), /拒绝覆盖已有文件/);
+      assert.deepEqual(await Promise.all(backupNames.map((name) => readFile(path.join(backupDirectory, name)))), completedBackup);
+
+      await assert.rejects(
+        runOperation("restore-new", { ...restoreVariables, TARGET_DB_NAME: "" }, backupDirectory),
+        (error: unknown) => {
+          assert.match(String((error as { stderr?: string }).stderr), /TARGET_DB_NAME/);
+          return true;
+        },
+      );
+      await assert.rejects(
+        runOperation("restore-new", { ...restoreVariables, TARGET_DB_NAME: "UnsafeName" }, backupDirectory),
+        /最长 63 字节的小写 PostgreSQL 标识符/,
+      );
+      await assert.rejects(
+        runOperation("restore-new", { ...restoreVariables, TARGET_DB_APP_USER: "a".repeat(64) }, backupDirectory),
+        /最长 63 字节的小写 PostgreSQL 标识符/,
+      );
+      await assert.rejects(
+        runOperation("restore-new", { ...restoreVariables, TARGET_DB_NAME: sourceVariables.SOURCE_DB_NAME }, backupDirectory),
+        (error: unknown) => {
+          assert.match(String((error as { stderr?: string }).stderr), /来源库与目标库不能相同/);
+          return true;
+        },
+      );
+
+      await runOperation("restore-new", restoreVariables, backupDirectory);
+      const sourceSummary = await runOperation("summary", sourceVariables, backupDirectory);
+      assert.equal(sourceSummary.stdout, await readFile(path.join(backupDirectory, "sampleflow.dump.summary"), "utf8"));
+      const targetSummary = await runOperation("summary", {
+        ...sourceVariables,
+        SOURCE_DB_NAME: targetName,
+      }, backupDirectory);
+      assert.equal(targetSummary.stdout, sourceSummary.stdout);
+      assert.match(sourceSummary.stdout, /^schema_migrations\|23\|[a-f0-9]{32}$/m);
+      assert.match(sourceSummary.stdout, /^users\|1\|[a-f0-9]{32}$/m);
+
+      const appDatabaseUrl = roleUrl(targetUrl.toString(), roles.app, roles.appPassword);
+      const appClient = new Client({ connectionString: appDatabaseUrl });
+      const backupClient = new Client({ connectionString: roleUrl(targetUrl.toString(), roles.backup, roles.backupPassword) });
+      await appClient.connect();
+      await backupClient.connect();
+      try {
+        await assert.rejects(appClient.query("create table forbidden_restore_ddl(id integer)"), /permission denied/);
+        await assert.rejects(backupClient.query("insert into app_metadata(key,value) values('forbidden-restore','write')"), /permission denied/);
+      } finally {
+        await appClient.end();
+        await backupClient.end();
+      }
+
+      await withTestApi(appDatabaseUrl, async (app) => {
+        const ready = await app.inject({ method: "GET", url: "/api/ready" });
+        assert.deepEqual(ready.json(), { status: "ready", database: "connected" });
+        const login = await app.inject({
+          method: "POST",
+          url: "/api/auth/login",
+          headers: { origin: "http://127.0.0.1:4174" },
+          payload: { username: "restore_smoke", password: "Restore@123" },
+        });
+        assert.equal(login.statusCode, 200, login.body);
+      });
+
+      await assert.rejects(
+        runOperation("restore-new", restoreVariables, backupDirectory),
+        (error: unknown) => {
+          assert.match(String((error as { stderr?: string }).stderr), /目标数据库已存在/);
+          return true;
+        },
+      );
+
+      const summaryPath = path.join(backupDirectory, "sampleflow.dump.summary");
+      await appendFile(summaryPath, "tampered\n");
+      const summaryHash = createHash("sha256").update(await readFile(summaryPath)).digest("hex");
+      await writeFile(path.join(backupDirectory, "sampleflow.dump.summary.sha256"), `${summaryHash}  sampleflow.dump.summary\n`, "utf8");
+      await assert.rejects(
+        runOperation("restore-new", { ...restoreVariables, TARGET_DB_NAME: corruptTargetName }, backupDirectory),
+        (error: unknown) => {
+          assert.match(String((error as { stderr?: string }).stderr), /稳定摘要与来源不一致/);
+          return true;
+        },
+      );
+      const admin = new Client({ connectionString: source.adminUrl });
+      await admin.connect();
+      try {
+        assert.equal((await admin.query("select 1 from pg_database where datname=$1", [corruptTargetName])).rowCount, 0);
+        const targetDatabase = await admin.query<{ owner: string; public_connect: boolean }>(
+          `select pg_get_userbyid(d.datdba) owner,
+                  exists(select 1 from aclexplode(coalesce(d.datacl,acldefault('d',d.datdba))) acl
+                         where acl.grantee=0 and acl.privilege_type='CONNECT') public_connect
+           from pg_database d where d.datname=$1`,
+          [targetName],
+        );
+        assert.deepEqual(targetDatabase.rows[0], { owner: roles.migration, public_connect: false });
+      } finally {
+        await admin.end();
+      }
+    } finally {
+      const admin = new Client({ connectionString: source.adminUrl });
+      await admin.connect();
+      try {
+        for (const databaseName of [targetName, corruptTargetName]) {
+          await admin.query("select pg_terminate_backend(pid) from pg_stat_activity where datname=$1 and pid<>pg_backend_pid()", [databaseName]);
+          await admin.query(`drop database if exists "${databaseName}"`);
+        }
+      } finally {
+        await admin.end();
+        await rm(backupDirectory, { recursive: true, force: true });
+      }
+    }
+    });
+  } finally {
+    if (roleCleanup) await dropRoles(roleCleanup.adminUrl, roleCleanup.roles);
+  }
+});

--- a/scripts/database-operations.sh
+++ b/scripts/database-operations.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+fail() {
+  printf '%s\n' "[数据库备份恢复] $1" >&2
+  exit 2
+}
+
+require() {
+  [[ -n "${!1:-}" ]] || fail "必须显式设置 $1"
+}
+
+require_identifier() {
+  require "$1"
+  [[ "${!1}" =~ ^[a-z][a-z0-9_]{0,62}$ ]] || fail "$1 必须是最长 63 字节的小写 PostgreSQL 标识符"
+}
+
+require_source() {
+  for name in SOURCE_DB_HOST SOURCE_DB_PORT SOURCE_DB_NAME SOURCE_DB_USER SOURCE_DB_PASSWORD; do require "$name"; done
+  require_identifier SOURCE_DB_NAME
+}
+
+database_summary() {
+  local host="$1" port="$2" database="$3" user="$4" password="$5"
+  PGPASSWORD="$password" psql -X -qAt --set ON_ERROR_STOP=1 \
+    --host="$host" --port="$port" --dbname="$database" --username="$user" <<'SQL'
+begin isolation level repeatable read read only;
+select 'schema_migrations|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from schema_migrations t;
+select 'app_metadata|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from app_metadata t;
+select 'roles|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from roles t;
+select 'users|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from users t;
+select 'user_roles|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from user_roles t;
+select 'people|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from people t;
+select 'org_units|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from org_units t;
+select 'org_assignments|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from org_assignments t;
+select 'org_memberships|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from org_memberships t;
+select 'org_responsibilities|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from org_responsibilities t;
+select 'performance_orders|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from performance_orders t;
+select 'performance_events|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from performance_events t;
+select 'performance_event_analysis_dimensions|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from performance_event_analysis_dimensions t;
+select 'goals|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from goals t;
+select 'goal_versions|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from goal_versions t;
+select 'goal_approvals|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from goal_approvals t;
+select 'goal_change_requests|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from goal_change_requests t;
+select 'goal_linkage_decisions|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from goal_linkage_decisions t;
+select 'accounting_periods|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from accounting_periods t;
+select 'accounting_period_closures|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from accounting_period_closures t;
+select 'accounting_correction_requests|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from accounting_correction_requests t;
+select 'historical_order_reviews|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from historical_order_reviews t;
+select 'import_configs|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from import_configs t;
+select 'import_batches|'||count(*)||'|'||md5(coalesce(string_agg(((to_jsonb(t)-'source_bytes')||jsonb_build_object('source_bytes_md5',md5(source_bytes)))::text,E'\n' order by ((to_jsonb(t)-'source_bytes')||jsonb_build_object('source_bytes_md5',md5(source_bytes)))::text),'')) from import_batches t;
+select 'import_batch_rows|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from import_batch_rows t;
+select 'legacy_import_runs|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from legacy_import_runs t;
+select 'organization_import_runs|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from organization_import_runs t;
+select 'legacy_event_import_reconciliations|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from legacy_event_import_reconciliations t;
+select 'legacy_event_source_evidence|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from legacy_event_source_evidence t;
+select 'legacy_event_analysis_dimension_backfills|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from legacy_event_analysis_dimension_backfills t;
+select 'audit_logs|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),'')) from audit_logs t;
+select 'sequences|'||count(*)||'|'||md5(coalesce(string_agg(to_jsonb(t)::text,E'\n' order by to_jsonb(t)::text),''))
+from (select schemaname,sequencename,data_type,start_value,min_value,max_value,increment_by,cycle,cache_size,last_value from pg_sequences where schemaname='public') t;
+commit;
+SQL
+}
+
+source_summary() {
+  database_summary "$SOURCE_DB_HOST" "$SOURCE_DB_PORT" "$SOURCE_DB_NAME" "$SOURCE_DB_USER" "$SOURCE_DB_PASSWORD"
+}
+
+backup() {
+  require_source
+  require BACKUP_FILE
+  [[ "$BACKUP_FILE" == /* ]] || fail "BACKUP_FILE 必须是容器内绝对路径"
+  local directory filename temporary before after sha summary_sha lock lock_created=0 outputs_owned=0 committed=0 output
+  directory="$(dirname "$BACKUP_FILE")"
+  filename="$(basename "$BACKUP_FILE")"
+  [[ "$filename" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]] || fail "备份文件名只能包含字母、数字、点、下划线和连字符"
+  [[ -d "$directory" ]] || fail "备份目录不存在"
+  temporary="$BACKUP_FILE.partial.$$"
+  before="$BACKUP_FILE.summary.before.$$"
+  after="$BACKUP_FILE.summary.after.$$"
+  sha="$BACKUP_FILE.sha256.partial.$$"
+  summary_sha="$BACKUP_FILE.summary.sha256.partial.$$"
+  lock="$BACKUP_FILE.lock"
+  cleanup_backup() {
+    local status="$1" cleanup_failed=0
+    if [[ "$lock_created" == 1 ]]; then
+      if ! rm -f -- "$temporary" "$before" "$after" "$sha" "$summary_sha"; then
+        printf '%s\n' "[数据库备份恢复] CLEANUP_FAILED：无法删除本次备份临时文件" >&2
+        cleanup_failed=1
+      fi
+      if [[ "$outputs_owned" == 1 && "$committed" != 1 ]]; then
+        if ! rm -f -- "$BACKUP_FILE" "$BACKUP_FILE.sha256" "$BACKUP_FILE.summary" "$BACKUP_FILE.summary.sha256"; then
+          printf '%s\n' "[数据库备份恢复] CLEANUP_FAILED：无法删除本次未完成备份" >&2
+          cleanup_failed=1
+        fi
+      fi
+      if ! rmdir -- "$lock"; then
+        printf '%s\n' "[数据库备份恢复] CLEANUP_FAILED：无法释放备份锁 $lock" >&2
+        cleanup_failed=1
+      fi
+    fi
+    [[ "$cleanup_failed" == 0 ]] || return 3
+    return "$status"
+  }
+  trap 'cleanup_backup "$?"' EXIT
+
+  mkdir -- "$lock" 2>/dev/null || fail "备份路径已存在或正在由其他进程写入：$filename"
+  lock_created=1
+  for output in "$BACKUP_FILE" "$BACKUP_FILE.sha256" "$BACKUP_FILE.summary" "$BACKUP_FILE.summary.sha256"; do
+    [[ ! -e "$output" ]] || fail "拒绝覆盖已有文件：$(basename "$output")"
+  done
+  outputs_owned=1
+  rm -f -- "$temporary" "$before" "$after" "$sha" "$summary_sha"
+
+  source_summary > "$before"
+  PGPASSWORD="$SOURCE_DB_PASSWORD" pg_dump --format=custom --compress=6 --no-owner \
+    --host="$SOURCE_DB_HOST" --port="$SOURCE_DB_PORT" --dbname="$SOURCE_DB_NAME" --username="$SOURCE_DB_USER" \
+    --file="$temporary"
+  pg_restore --list "$temporary" > /dev/null
+  source_summary > "$after"
+  if ! cmp -s "$before" "$after"; then
+    diff -u "$before" "$after" >&2 || true
+    fail "来源库在备份期间发生变化，备份已拒绝"
+  fi
+
+  printf '%s  %s\n' "$(sha256sum "$temporary" | cut -d' ' -f1)" "$filename" > "$sha"
+  printf '%s  %s\n' "$(sha256sum "$before" | cut -d' ' -f1)" "$filename.summary" > "$summary_sha"
+  mv -- "$temporary" "$BACKUP_FILE"
+  mv -- "$before" "$BACKUP_FILE.summary"
+  mv -- "$sha" "$BACKUP_FILE.sha256"
+  mv -- "$summary_sha" "$BACKUP_FILE.summary.sha256"
+  committed=1
+  printf '%s\n' "[数据库备份恢复] 备份、SHA-256 与来源摘要已生成：$filename"
+  cleanup_backup 0
+  trap - EXIT
+}
+
+restore_new() {
+  require_source
+  require BACKUP_FILE
+  local name input
+  for name in TARGET_DB_HOST TARGET_DB_PORT TARGET_DB_ADMIN_NAME TARGET_DB_ADMIN_USER TARGET_DB_ADMIN_PASSWORD TARGET_DB_NAME TARGET_DB_OWNER TARGET_DB_OWNER_PASSWORD TARGET_DB_APP_USER TARGET_DB_BACKUP_USER; do require "$name"; done
+  require_identifier TARGET_DB_ADMIN_NAME
+  require_identifier TARGET_DB_NAME
+  require_identifier TARGET_DB_OWNER
+  require_identifier TARGET_DB_APP_USER
+  require_identifier TARGET_DB_BACKUP_USER
+  [[ "$TARGET_DB_OWNER" != "$TARGET_DB_APP_USER" && "$TARGET_DB_OWNER" != "$TARGET_DB_BACKUP_USER" && "$TARGET_DB_APP_USER" != "$TARGET_DB_BACKUP_USER" ]] || fail "目标迁移、应用和备份账号必须不同"
+  [[ "$BACKUP_FILE" == /* ]] || fail "BACKUP_FILE 必须是容器内绝对路径"
+  local filename source_database source_server target_server existing role_count summary_file target_created=0 committed=0
+  filename="$(basename "$BACKUP_FILE")"
+  [[ "$filename" =~ ^[a-zA-Z0-9][a-zA-Z0-9._-]*$ ]] || fail "备份文件名只能包含字母、数字、点、下划线和连字符"
+  for input in "$BACKUP_FILE" "$BACKUP_FILE.sha256" "$BACKUP_FILE.summary" "$BACKUP_FILE.summary.sha256"; do
+    [[ -f "$input" && ! -L "$input" ]] || fail "备份或清单缺失：$(basename "$input")"
+  done
+  [[ "$(<"$BACKUP_FILE.sha256")" == "$(sha256sum "$BACKUP_FILE" | cut -d' ' -f1)  $filename" ]] || fail "备份 SHA-256 校验失败"
+  [[ "$(<"$BACKUP_FILE.summary.sha256")" == "$(sha256sum "$BACKUP_FILE.summary" | cut -d' ' -f1)  $filename.summary" ]] || fail "摘要 SHA-256 校验失败"
+  pg_restore --list "$BACKUP_FILE" > /dev/null || fail "备份不是可解析的 PostgreSQL custom 格式"
+
+  source_database="$(PGPASSWORD="$SOURCE_DB_PASSWORD" psql -X -qAt --set ON_ERROR_STOP=1 --host="$SOURCE_DB_HOST" --port="$SOURCE_DB_PORT" --dbname="$SOURCE_DB_NAME" --username="$SOURCE_DB_USER" --command='select current_database()')"
+  [[ "$source_database" == "$SOURCE_DB_NAME" ]] || fail "来源连接未指向显式来源库"
+  source_server="$(PGPASSWORD="$SOURCE_DB_PASSWORD" psql -X -qAt --set ON_ERROR_STOP=1 --host="$SOURCE_DB_HOST" --port="$SOURCE_DB_PORT" --dbname="$SOURCE_DB_NAME" --username="$SOURCE_DB_USER" --command="select coalesce(inet_server_addr()::text,'local')||':'||inet_server_port()")"
+  target_server="$(PGPASSWORD="$TARGET_DB_ADMIN_PASSWORD" psql -X -qAt --set ON_ERROR_STOP=1 --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --dbname="$TARGET_DB_ADMIN_NAME" --username="$TARGET_DB_ADMIN_USER" --command="select coalesce(inet_server_addr()::text,'local')||':'||inet_server_port()")"
+  [[ "$source_server|$SOURCE_DB_NAME" != "$target_server|$TARGET_DB_NAME" ]] || fail "来源库与目标库不能相同"
+
+  existing="$(PGPASSWORD="$TARGET_DB_ADMIN_PASSWORD" psql -X -qAt --set ON_ERROR_STOP=1 --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --dbname="$TARGET_DB_ADMIN_NAME" --username="$TARGET_DB_ADMIN_USER" --command="select 1 from pg_database where datname='$TARGET_DB_NAME'")"
+  [[ -z "$existing" ]] || fail "目标数据库已存在，恢复只允许创建新库"
+  role_count="$(PGPASSWORD="$TARGET_DB_ADMIN_PASSWORD" psql -X -qAt --set ON_ERROR_STOP=1 --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --dbname="$TARGET_DB_ADMIN_NAME" --username="$TARGET_DB_ADMIN_USER" --command="select count(*) from pg_roles where rolname in ('$TARGET_DB_OWNER','$TARGET_DB_APP_USER','$TARGET_DB_BACKUP_USER')")"
+  [[ "$role_count" == 3 ]] || fail "目标迁移、应用或备份角色不存在"
+
+  summary_file="$BACKUP_FILE.target-summary.$$"
+  cleanup_restore() {
+    local status="$1" cleanup_failed=0
+    rm -f -- "$summary_file" || cleanup_failed=1
+    if [[ "$target_created" == 1 && "$committed" != 1 ]]; then
+      if ! PGPASSWORD="$TARGET_DB_ADMIN_PASSWORD" dropdb --force --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --username="$TARGET_DB_ADMIN_USER" --maintenance-db="$TARGET_DB_ADMIN_NAME" "$TARGET_DB_NAME"; then
+        printf '%s\n' "[数据库备份恢复] CLEANUP_FAILED：未能删除未完成目标库 $TARGET_DB_NAME，请立即隔离并人工清理" >&2
+        cleanup_failed=1
+      fi
+    fi
+    [[ "$cleanup_failed" == 0 ]] || return 3
+    return "$status"
+  }
+  trap 'cleanup_restore "$?"' EXIT
+
+  PGPASSWORD="$TARGET_DB_ADMIN_PASSWORD" createdb --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --username="$TARGET_DB_ADMIN_USER" \
+    --maintenance-db="$TARGET_DB_ADMIN_NAME" --owner="$TARGET_DB_OWNER" "$TARGET_DB_NAME"
+  target_created=1
+  PGPASSWORD="$TARGET_DB_OWNER_PASSWORD" pg_restore --exit-on-error --single-transaction --no-owner \
+    --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --dbname="$TARGET_DB_NAME" --username="$TARGET_DB_OWNER" "$BACKUP_FILE"
+  PGPASSWORD="$TARGET_DB_ADMIN_PASSWORD" psql -X -qAt --set ON_ERROR_STOP=1 \
+    --host="$TARGET_DB_HOST" --port="$TARGET_DB_PORT" --dbname="$TARGET_DB_ADMIN_NAME" --username="$TARGET_DB_ADMIN_USER" <<SQL
+revoke all on database $TARGET_DB_NAME from public;
+grant connect,create,temp on database $TARGET_DB_NAME to $TARGET_DB_OWNER;
+grant connect on database $TARGET_DB_NAME to $TARGET_DB_APP_USER,$TARGET_DB_BACKUP_USER;
+SQL
+  database_summary "$TARGET_DB_HOST" "$TARGET_DB_PORT" "$TARGET_DB_NAME" "$TARGET_DB_OWNER" "$TARGET_DB_OWNER_PASSWORD" > "$summary_file"
+  cmp -s "$BACKUP_FILE.summary" "$summary_file" || fail "恢复库 schema、关键数量或稳定摘要与来源不一致"
+  committed=1
+  printf '%s\n' "[数据库备份恢复] 已恢复并校验新目标库：$TARGET_DB_NAME"
+  cleanup_restore 0
+  trap - EXIT
+}
+
+case "${1:-}" in
+  backup) backup ;;
+  restore-new) restore_new ;;
+  summary) require_source; source_summary ;;
+  *) fail "用法：database-operations.sh backup|restore-new|summary" ;;
+esac


### PR DESCRIPTION
## 完成内容
- PostgreSQL custom-format 备份与 SHA-256 清单
- 备份前后稳定摘要核对，并发与拒绝覆盖保护
- 仅恢复到显式新库，失败自动删除本次未完成目标
- 保留最小权限 ACL，关闭 PUBLIC CONNECT
- 独立 migration/app/backup 账号完成恢复、readiness 与登录验收

## 验证
- npm.cmd run verify
- API 149/149
- Web 34/34
- 容器契约 6/6
- 构建、容器运行、npm audit、Compose 配置通过

Closes #61