### PR TITLE
fix(web): remove map footnote text

### DIFF
--- a/apps/web/e2e/analysis.spec.ts
+++ b/apps/web/e2e/analysis.spec.ts
@@ -119,7 +119,8 @@ test("业绩分析页显示事件快照地区、外贸、客户单位和待补�
   await expect(map.locator(".analysis-map-boundary")).toHaveCount(0);
   const southernEdge = await map.locator("[data-region-code]").evaluateAll((elements) => Math.max(...elements.map((element) => { const box = (element as SVGGraphicsElement).getBBox(); return box.y + box.height; })));
   expect(southernEdge).toBeLessThanOrEqual(608.01);
-  await expect(analysis.getByText("台湾省 1 条事件 · ¥10.00", { exact: true })).toBeVisible();
+  await expect(analysis.getByText("台湾省 1 条事件 · ¥10.00", { exact: true })).toHaveCount(0);
+  await expect(analysis.getByText(/省级轮廓/)).toHaveCount(0);
   const jiangsu = map.getByRole("button", { name: "地图选择江苏省，102 条事件，金额 ¥101,000,000,000,098.99" });
   const zhejiang = map.getByRole("button", { name: "地图选择浙江省，1 条事件，金额 ¥50.00" });
   await expect(jiangsu).toBeVisible();
@@ -247,7 +248,7 @@ test("第二批客户穿透可通过刷新和浏览器历史恢复", async ({ da
   await page.getByLabel("账号").fill("e2e_analysis_restore");
   await page.getByLabel("密码", { exact: true }).fill("Analysis@123");
   await page.getByRole("button", { name: "进入 SampleFlow" }).click();
-  await expect(page.getByText("台湾省资料暂缺", { exact: true })).toBeVisible();
+  await expect(page.getByText("台湾省资料暂缺", { exact: true })).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "客户51月度趋势" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "2026年8月订单与事件" })).toBeVisible();
   expect(customerRequests).toBeGreaterThanOrEqual(2);

--- a/apps/web/src/pages/analysis-page.tsx
+++ b/apps/web/src/pages/analysis-page.tsx
@@ -38,7 +38,6 @@ function ChinaProvinceMap({provinces,selectedRegionCode,onSelect}:{provinces:Ana
   const[mapError,setMapError]=useState("");
   useEffect(()=>{const controller=new AbortController();import("../china-map").then(({loadChinaMap})=>loadChinaMap(controller.signal)).then(setChinaMap).catch((failure)=>{if(failure instanceof DOMException&&failure.name==="AbortError")return;setMapError(failure instanceof Error?failure.message:"中国省级地图加载失败");});return()=>controller.abort();},[]);
   const byCode=new Map(provinces.map((province)=>[province.regionCode,province]));
-  const taiwan=byCode.get("CN-TW");
   const finiteTotals=provinces.map((province)=>Math.abs(Number(province.totalAmount))).filter(Number.isFinite);
   const maximum=Math.max(1,...finiteTotals);
   return <article className="analysis-card analysis-map-card"><h3>省份地图</h3><div className="analysis-map-wrap">{chinaMap?<svg className="analysis-map" viewBox={chinaMap.viewBox} role="group" aria-label="中国省份业绩地图">{chinaMap.locations.map((location)=>{
@@ -48,7 +47,7 @@ function ChinaProvinceMap({provinces,selectedRegionCode,onSelect}:{provinces:Ana
     const selected=selectedRegionCode===province.regionCode;
     const label=`地图选择${province.regionName}，${province.eventCount} 条事件，金额 ${formatMoney(province.totalAmount)}`;
     return <path key={location.id} d={location.path} className={`analysis-map-region${Number(province.totalAmount)<0?" negative":""}${selected?" selected":""}`} style={{fillOpacity:.3+.7*Math.abs(Number(province.totalAmount))/maximum}} data-region-code={regionCode} role="button" tabIndex={0} aria-label={label} aria-pressed={selected} onClick={()=>onSelect(province)} onKeyDown={(event)=>{if(event.key==="Enter"||event.key===" "){event.preventDefault();onSelect(province);}}}/>;
-  })}</svg>:<p className={mapError?"page-message":"analysis-loading"} role={mapError?"alert":"status"}>{mapError||"正在读取中国省级地图…"}</p>}<p>颜色深浅只表示相对规模；金额以右侧省份汇总为准。</p><p><span>{taiwan?`台湾省 ${taiwan.eventCount} 条事件 · ${formatMoney(taiwan.totalAmount)}`:"台湾省资料暂缺"}</span>；香港特别行政区、澳门特别行政区资料暂缺。</p><small>省级轮廓：<a href="https://www.tianditu.gov.cn/">天地图</a>来源；<a href="https://github.com/JayMuShui/chinese-global-compliant-geodata">chinese-global-compliant-geodata 1.0.0</a>（MIT）。</small></div></article>;
+  })}</svg>:<p className={mapError?"page-message":"analysis-loading"} role={mapError?"alert":"status"}>{mapError||"正在读取中国省级地图…"}</p>}<p>颜色深浅只表示相对规模；金额以右侧省份汇总为准。</p></div></article>;
 }
 
 function AnalysisDrilldown({province,month}:{province:AnalysisProvince;month:string}){


### PR DESCRIPTION
删除省份地图下方的台湾/港澳资料提示与地图来源说明。保留台湾省地图轮廓、统计表与随包第三方许可文件。

验证：Web typecheck、build、analysis.spec.ts 3/3 通过。