### PR TITLE
docs: 完成 P1 审查整改交接

### DIFF
--- a/handoff.md
+++ b/handoff.md
@@ -2,7 +2,7 @@
 
 > 更新时间：2026-09-02（America/Los_Angeles）
 >
-> 当前结论：**全仓复审新增的 6 个 P1 工程问题已建立为 #118—#123，并在现有 checkout 的 `codex/p1-audit-remediation` 分支完成修复与本地验收；尚待提交、PR CI、合并和远端关闭核验。之后剩余 P1 仍是人工 Gate：真实数据业务 UAT 与公司服务器验收。当前没有真实数据授权，也没有公司服务器，绝不能把自动化、合成数据或本机 Docker 结果冒充这些验收。**
+> 当前结论：**全仓复审新增的 6 个 P1 工程问题 #118—#123 已全部修复，经 PR #124、required check 和合并后 `main` quality gate 验证后进入 `main`，Issues 已自动关闭。当前版本没有剩余可由工程代理独立完成的 P1；剩余 P1 全部是人工 Gate：真实数据业务 UAT 与公司服务器验收。当前没有真实数据授权，也没有公司服务器，绝不能把自动化、合成数据或本机 Docker 结果冒充这些验收。**
 
 ## 1. 我们在做什么
 
@@ -36,11 +36,14 @@ SampleFlow 是销售业绩、目标、组织、账号和审计管理的桌面 We
 - 默认分支：`main`
 - UI/UX 审查交付：[PR #113](https://github.com/Eclipseic1848/SampleFlow/pull/113)，已 squash merge。
 - 统一页码分页交付：[Issue #116](https://github.com/Eclipseic1848/SampleFlow/issues/116) / [PR #117](https://github.com/Eclipseic1848/SampleFlow/pull/117)。
-- 本轮复审整改：[#118](https://github.com/Eclipseic1848/SampleFlow/issues/118)—[#123](https://github.com/Eclipseic1848/SampleFlow/issues/123)，本地分支 `codex/p1-audit-remediation`，PR 尚未创建。
+- 本轮复审整改：[#118](https://github.com/Eclipseic1848/SampleFlow/issues/118)—[#123](https://github.com/Eclipseic1848/SampleFlow/issues/123) / [PR #124](https://github.com/Eclipseic1848/SampleFlow/pull/124)，已 squash merge。
+- PR #124 合并提交：`fbc82c17f648a38831a9ae0b3b8035ce2349ef23`。
+- PR #124 required check：run `33618823240`，SUCCESS，5分45秒。
+- PR #124 合并后 `main` quality gate：run `33619359468`，SUCCESS，5分33秒。
 - PR #113 合并提交：`a1505add0191cb2bd4176bf01c993c523569ae27`
 - PR required check：run `33591249761`，SUCCESS，7分08秒。
 - 合并后 `main` quality gate：run `33591736403`，SUCCESS，5分29秒。
-- #101、#106—#112 已由 PR #113 自动关闭；#116 由 PR #117 自动关闭。
+- #101、#106—#112 已由 PR #113 自动关闭；#116 由 PR #117 自动关闭；#118—#123 由 PR #124 自动关闭。
 - 本轮没有创建 worktree 或额外项目目录。
 - 没有创建 Tag、GitHub Release，也没有部署到真实服务器。
 
@@ -53,7 +56,8 @@ git rev-parse HEAD
 git rev-parse origin/main
 gh pr view 113 --repo Eclipseic1848/SampleFlow
 gh pr view 117 --repo Eclipseic1848/SampleFlow
-gh issue view 116 --repo Eclipseic1848/SampleFlow
+gh pr view 124 --repo Eclipseic1848/SampleFlow
+gh issue view 123 --repo Eclipseic1848/SampleFlow
 gh issue list --repo Eclipseic1848/SampleFlow --label "priority:P1" --state open
 gh run list --repo Eclipseic1848/SampleFlow --workflow "SampleFlow quality gate" --limit 10
 docker compose -f docker-compose.dev.yml ps
@@ -61,9 +65,9 @@ docker compose -f docker-compose.dev.yml ps
 
 ### 2.2 当前 P1
 
-本轮 `ready-for-agent` P1 已完成本地实现，待 PR 合并自动关闭：
+本轮工程 P1 已合并并关闭：
 
-| Issue | 本地结果 |
+| Issue | 最终结果 |
 | --- | --- |
 | #118 金额精度与账本状态不变量 | 统一 API 两位小数校验；首次计入先按分舍入；迁移 025 在数据库层约束状态与金额组合 |
 | #119 读路径表级锁 | 删除账号、审计和分析查询中的 `LOCK TABLE ... SHARE`；回归证明读取不等待在途写入 |
@@ -100,7 +104,7 @@ https://github.com/Eclipseic1848/SampleFlow/issues/65#issuecomment-5504522089
 | #101 搜索与历史 | 账号、订单、审计搜索/分页与 URL、刷新、前进后退一致；冷启动深链不会伪造“上一页” |
 | #112 后台信息架构 | 创建账号明确“新建人员/绑定已有人员”和多角色；组织按部门/小组、当前/历史分组并支持搜索；文本域可垂直调整 |
 | #116 统一页码分页 | 所有数据表格与可增长业务清单默认 20 条，可选 10／20／50／100 条；支持总数、当前页／总页数、可点击页码、上一页和下一页；服务端大列表返回 `page`／`pageSize`／`totalCount`，旧游标调用保持兼容 |
-| #118—#123 全仓复审整改 | 金额边界和数据库不变量、无阻塞读取、超范围精确总数、稳定页码快照、异步引导与权威文档已完成本地修复；等待 PR/CI/合并 |
+| #118—#123 全仓复审整改 | 金额边界和数据库不变量、无阻塞读取、超范围精确总数、稳定页码快照、异步引导与权威文档已由 PR #124 合并，Issues 全部关闭 |
 
 ### 3.2 既有 P1 工程能力
 
@@ -132,6 +136,7 @@ https://github.com/Eclipseic1848/SampleFlow/issues/65#issuecomment-5504522089
 - PR #113 第二轮 required check：SUCCESS。
 - 合并后 `main` quality gate：SUCCESS。
 - PR #117 required check 与合并后 `main` quality gate：SUCCESS；实时 run ID 用第 2.1 节命令复核。
+- PR #124 required check：run `33618823240`，SUCCESS；合并后 `main` run `33619359468`，SUCCESS。
 
 首轮 PR CI 曾暴露三处 Linux 时序竞态，不是产品逻辑失败：
 
@@ -143,7 +148,7 @@ https://github.com/Eclipseic1848/SampleFlow/issues/65#issuecomment-5504522089
 
 ## 5. 当前卡点
 
-本轮代码与本地验收完成；当前工程步骤是提交、推送、创建 PR、等待 required check、合并并核验 #118—#123 关闭。完成后只剩人工 Gate：
+没有剩余可由工程代理独立完成的 P1。当前只剩人工 Gate：
 
 1. #63：缺真实数据授权、来源哈希、权威组织/区域映射、批准的隔离环境、业务验收人和签字。
 2. #64：缺公司服务器、域名/HTTPS、正式秘密、备份存储、监控、RPO/RTO、维护窗口和运维责任人。
@@ -151,13 +156,6 @@ https://github.com/Eclipseic1848/SampleFlow/issues/65#issuecomment-5504522089
 4. 没有外部发布授权；不得创建 Tag、GitHub Release 或真实部署。
 
 ## 6. 下一步计划
-
-### 6.0 当前分支收口
-
-1. 仅暂存本轮明确文件，提交并推送 `codex/p1-audit-remediation`。
-2. 创建包含 `Closes #118`—`Closes #123` 的 PR。
-3. required check 通过后 squash merge；核验 6 个 Issue 自动关闭和最新 `main` CI。
-4. 用最终 PR、merge SHA、run ID 和远端 P1 状态再次刷新本交接文档。
 
 ### 6.1 当真实数据条件齐全时
 


### PR DESCRIPTION
## 变更说明

- 将零上下文交接从“整改待合并”更新为最终远端事实。
- 记录 PR #124、合并提交、required check、合并后 main quality gate 和 #118—#123 关闭状态。
- 删除已完成的临时收口步骤，保留真实数据 UAT、公司服务器和外部发布人工门禁。

本 PR 仅更新交接文档，不修改产品代码。
