### PR TITLE
test: 稳定分析事件分页异步断言

### DIFF
--- a/apps/web/e2e/analysis.spec.ts
+++ b/apps/web/e2e/analysis.spec.ts
@@ -174,6 +174,7 @@ test("业绩分析页显示事件快照地区、外贸、客户单位和待补�
   await drilldown.getByRole("button", { name: "查看大额客户月份趋势" }).click();
   await drilldown.getByRole("button", { name: "查看2026年8月订单事件，101 条事件，金额 ¥100,999,999,999,998.99" }).click();
   const eventPageSize=drilldown.getByLabel("订单事件每页条数");
+  await expect(eventPageSize).toBeVisible();
   expect(await eventPageSize.locator("option").allTextContents()).toEqual(["10 条/页","20 条/页","50 条/页","100 条/页"]);
   await eventPageSize.selectOption("100");
   await expect(drilldown.getByText("本页 100 / 共 101 条事件", { exact: true })).toBeVisible();

--- a/handoff.md
+++ b/handoff.md
@@ -2,7 +2,7 @@
 
 > 更新时间：2026-09-02（America/Los_Angeles）
 >
-> 核心结论：本轮工程目标由 [Issue #127](https://github.com/Eclipseic1848/SampleFlow/issues/127) / [PR #128](https://github.com/Eclipseic1848/SampleFlow/pull/128) 承载。代码和本地验收已完成；PR、CI、合并及 Issue 状态必须实时查询，不在本文缓存易失状态。没有导入真实工作簿，没有移动端，也没有公司服务器或外部发布。
+> 核心结论：Sheet3 工程目标由 [Issue #127](https://github.com/Eclipseic1848/SampleFlow/issues/127) / [PR #128](https://github.com/Eclipseic1848/SampleFlow/pull/128) 承载；合并后暴露的分析分页 E2E 时序问题由 [Issue #129](https://github.com/Eclipseic1848/SampleFlow/issues/129) / [PR #130](https://github.com/Eclipseic1848/SampleFlow/pull/130) 收口。代码和本地验收已完成；PR、CI、合并及 Issue 状态必须实时查询，不在本文缓存易失状态。没有导入真实工作簿，没有移动端，也没有公司服务器或外部发布。
 
 ## 1. 我们在做什么
 
@@ -64,7 +64,7 @@ SampleFlow 是销售业绩、目标、组织、账号和审计管理的桌面 We
 本地最终验收：
 
 - API 全量测试：164/164 通过。
-- Web Playwright：一次全量 49/50；唯一失败为既有 200% 缩放用例的 `Shift+Tab` 瞬时焦点断言，同一 1024 场景通过，随后 1280 场景连续复跑 3/3 通过。本次关账更正为负数场景定向通过。最终远端结论以 PR #128 required check 为准。
+- Web Playwright：PR #128 required check 全量通过。本机另一次全量为 49/50，唯一失败的 200% 缩放焦点断言随后连续复跑 3/3 通过。PR 合并后的 `main` run 33712729772 暴露分析事件分页在异步控件出现前读取选项，已在 PR #130 增加可见性等待，两个宽度各连续 3 次、共 6/6 通过。最终远端结论以 PR #130 及其合并后 `main` check 为准。
 - TypeScript 类型检查：API、Web 通过。
 - 生产构建：API、Web 通过；Vite 共转换 1940 个模块。
 - 容器契约：11/11 通过。
@@ -78,7 +78,7 @@ SampleFlow 是销售业绩、目标、组织、账号和审计管理的桌面 We
 
 ## 4. 当前状态与卡点
 
-本轮工程交付：Issue #127 / PR #128。新会话必须先实时核对：
+本轮工程交付：Issue #127 / PR #128；CI 稳定性收口：Issue #129 / PR #130。新会话必须先实时核对：
 
 ```powershell
 Set-Location -LiteralPath 'F:\new branch\SampleFlow'
@@ -87,7 +87,9 @@ git fetch origin main
 git rev-parse HEAD
 git rev-parse origin/main
 gh pr view 128 --repo Eclipseic1848/SampleFlow --json state,mergeStateStatus,statusCheckRollup,mergedAt,mergeCommit,url
+gh pr view 130 --repo Eclipseic1848/SampleFlow --json state,mergeStateStatus,statusCheckRollup,mergedAt,mergeCommit,url
 gh issue view 127 --repo Eclipseic1848/SampleFlow --json state,labels,url
+gh issue view 129 --repo Eclipseic1848/SampleFlow --json state,labels,url
 gh issue list --repo Eclipseic1848/SampleFlow --state open --label 'priority:P1'
 gh run list --repo Eclipseic1848/SampleFlow --workflow 'SampleFlow quality gate' --limit 10
 docker compose -f docker-compose.dev.yml ps
@@ -107,11 +109,11 @@ docker compose -f docker-compose.dev.yml ps
 
 ## 5. 下一步计划
 
-### 5.1 当前 PR 尚未合并时
+### 5.1 当前 CI 收口 PR 尚未合并时
 
-1. 查看 PR #128 required check；失败则基于日志定位并修复，不能盲目重跑掩盖失败。
-2. required check 全绿且可合并后 squash merge，让 `Closes #127` 自动关闭 Issue。
-3. 合并后确认 `main` quality gate；若失败，修复到绿。
+1. 先确认 PR #128 已合并、Issue #127 已关闭，再查看 PR #130 required check。
+2. PR #130 required check 全绿且可合并后 squash merge，让 `Closes #129` 自动关闭 Issue。
+3. 合并后确认 `main` quality gate；若失败，继续基于日志修复到绿，不能仅重跑掩盖失败。
 4. 不新建 worktree，不切到额外目录；继续使用当前 checkout。
 
 ### 5.2 真实数据条件齐全后
@@ -137,7 +139,7 @@ docker compose -f docker-compose.dev.yml ps
 | 阶段 | 状态 | 退出条件 |
 | --- | --- | --- |
 | P0 | 已完成 | 权限、组织、账本、目标、认证、导入和可重复验收进入 `main` |
-| P1 工程波次 | 本轮候选为 PR #128 | PR/CI/合并状态实时核对；Issue #127 关闭 |
+| P1 工程波次 | Sheet3 为 PR #128；CI 收口为 PR #130 | 两个 PR/Issue 关闭且合并后 `main` quality gate 成功 |
 | P1 人工 Gate | 等待 | #63 真实数据 UAT、#64 公司服务器及父项/总验收关闭 |
 | v1.1-alpha | 工程基线可内部评估，未发布 | 不代表生产资格或外部发布 |
 | v1.1-rc | 未达到 | 真实数据 UAT、服务器、备份恢复、安全、业务与运维签字齐全 |
@@ -164,7 +166,7 @@ docker compose -f docker-compose.dev.yml ps
 14. 不要丢弃用户改动或批量清理环境；禁止 `reset --hard`、广泛 clean/checkout/add/stash，只暂存明确文件，只清理已核对的隔离 Docker 资源。
 15. CI 绿色不等于真实数据 UAT、服务器验收或发布；四类证据分别取证、分别授权。
 16. GitHub 写入遇到 TLS/EOF 或结果不确定时先查远端，不能重复创建 Issue、PR 或合并。
-17. 200% 缩放焦点用例曾有一次时序抖动；先定向重复验证并看 trace，不能直接删除断言或把失败当通过。
+17. E2E 异步页面不能用 `allTextContents()` 立即读取尚未出现的控件；先等待目标可见。200% 缩放焦点也曾有一次时序抖动；先定向重复验证并看 trace，不能删除断言或把失败当通过。
 18. 不要自动进入 P2、恢复移动端、迁移真实数据、部署服务器或发布版本。
 
 ## 8. 新会话接手顺序
@@ -173,6 +175,6 @@ docker compose -f docker-compose.dev.yml ps
 2. 阅读 `AGENTS.md`、`CONTEXT.md`、`docs/agents/`、ADR-0031 和相关规格。
 3. 执行第 4 节的只读 Git/GitHub/Docker 复核，以实时证据覆盖本文中的易变状态。
 4. 保护当前 checkout，不创建新 worktree。
-5. 若 PR #128 尚未收口，先完成其 CI/合并；若已完成且真实数据/服务器条件仍不存在，只报告人工门禁，不伪造进展。
+5. 若 PR #130 尚未收口，先完成其 CI/合并和合并后 `main` 验证；若已完成且真实数据/服务器条件仍不存在，只报告人工门禁，不伪造进展。
 
 接手原则：实时证据优先；工程、真实数据 UAT、服务器验收和外部发布分别取证、分别授权。


### PR DESCRIPTION
## 结果

- 分析页进入订单事件层后，先等待异步分页选择器可见，再读取选项。
- 不修改产品逻辑，不删除断言，不以重跑代替修复。

## 证据

- main 失败 run：33712729772
- 定向回归：desktop-1280 与 desktop-1024 各连续 3 次，共 6/6 通过。

Closes #129